### PR TITLE
Update 5.12.5

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -38,7 +38,8 @@ import { DynamicBackground } from "@spikerko/tools/DynamicBackground";
 // In development: import "./components/Utils/Annotations";
 import App from "./ready.ts";
 import { CloseSidebarLyrics, getQueueContainer, isSpicySidebarMode, OpenSidebarLyrics, RegisterSidebarLyrics } from "./components/Utils/SidebarLyrics.ts";
-import { Spicetify } from "@spicetify/bundler"
+import { Spicetify } from "@spicetify/bundler";
+import "./css/polyfills/tippy-polyfill.css";
 
 async function main() {
   await Platform.OnSpotifyReady;
@@ -142,7 +143,7 @@ async function main() {
   }
 
 
-  Defaults.SpicyLyricsVersion = window._spicy_lyrics_metadata?.LoadedVersion ?? "5.11.1";
+  Defaults.SpicyLyricsVersion = window._spicy_lyrics_metadata?.LoadedVersion ?? "5.12.0";
   
 
   /* if (storage.get("lyrics_spacing")) {

--- a/src/components/Utils/SidebarLyrics.ts
+++ b/src/components/Utils/SidebarLyrics.ts
@@ -4,26 +4,38 @@ import storage from "../../utils/storage.ts";
 import { currentBgInstance as currentPageBgInstance, SetPageBGBlur } from "../DynamicBG/dynamicBackground.ts";
 import { Spicetify } from "@spicetify/bundler";
 
+// Query selector functions
+const getSpicySidebarActiveBody = () => document.body;
+const getRootRightSidebar = () => document.querySelector<HTMLElement>('.Root__right-sidebar');
+const getNowPlayingViewElement = () => document.querySelector<HTMLElement>(".Root__right-sidebar aside.NowPlayingView");
+const getDesktopPanelContainer = () => document.querySelector<HTMLElement>(`.Root__right-sidebar aside#Desktop_PanelContainer_Id:has(.main-nowPlayingView-coverArtContainer)`);
+const getRightSidebarParentContainer = () => document.querySelector<HTMLElement>('.Root__right-sidebar .XOawmCGZcQx4cesyNfVO') ?? document.querySelector<HTMLElement>('.Root__right-sidebar .oXO9_yYs6JyOwkBn8E4a');
+const getQueueContainerElement = () => 
+    document.querySelector<HTMLElement>(".Root__right-sidebar .XOawmCGZcQx4cesyNfVO:not(:has(.h0XG5HZ9x0lYV7JNwhoA.JHlPg4iOkqbXmXjXwVdo)):has(.jD_TVjbjclUwewP7P9e8)") ??
+    document.querySelector<HTMLElement>(".Root__right-sidebar .oXO9_yYs6JyOwkBn8E4a:not(:has(.Ot1yAtVbjD2owYqmw6BK)):has(.ZWs_BNtabE4F1v34pU93.mpdgC9UTkN5_fMm1pFiz)");
+const getDevicesContainerElement = () => document.querySelector<HTMLElement>(".Root__right-sidebar .oXO9_yYs6JyOwkBn8E4a:has(.Ot1yAtVbjD2owYqmw6BK)");
+const getSpicyLyricsPageElement = () => document.querySelector<HTMLElement>('#SpicyLyricsPage');
+const getParentContainerChildren = (parentContainer: HTMLElement) => parentContainer.querySelector<HTMLElement>(':scope > *:not(#SpicyLyricsPage)');
+
 export const getNowPlayingViewPlaybarButton = () => {
     // console.log("[Spicy Lyrics Debug] getNowPlayingViewPlaybarButton");
     return document.querySelector<HTMLElement>('[data-testid="control-button-npv"]');
 };
 export const getNowPlayingViewContainer = () => {
     // console.log("[Spicy Lyrics Debug] getNowPlayingViewContainer");
-    return document.querySelector<HTMLElement>(".Root__right-sidebar aside.NowPlayingView") ??
-           document.querySelector<HTMLElement>(`.Root__right-sidebar aside#Desktop_PanelContainer_Id:has(.main-nowPlayingView-coverArtContainer)`);
+    return getNowPlayingViewElement() ?? getDesktopPanelContainer();
 };
 export const getNowPlayingViewParentContainer = () => {
     // console.log("[Spicy Lyrics Debug] getNowPlayingViewParentContainer");
-    return document.querySelector<HTMLElement>('.Root__right-sidebar .XOawmCGZcQx4cesyNfVO');
+    return getRightSidebarParentContainer();
 };
 const appendOpen = () => {
     // console.log("[Spicy Lyrics Debug] appendOpen");
-    document.body.classList.add("SpicySidebarLyrics__Active");
+    getSpicySidebarActiveBody().classList.add("SpicySidebarLyrics__Active");
 };
 const appendClosed = () => {
     // console.log("[Spicy Lyrics Debug] appendClosed");
-    document.body.classList.remove("SpicySidebarLyrics__Active");
+    getSpicySidebarActiveBody().classList.remove("SpicySidebarLyrics__Active");
 };
 
 export const getQueuePlaybarButton = () => {
@@ -37,7 +49,7 @@ const getDevicesPlaybarButton = () => {
 };
 
 export const getQueueContainer = () => {
-    return document.querySelector<HTMLElement>(".Root__right-sidebar .XOawmCGZcQx4cesyNfVO:not(:has(.h0XG5HZ9x0lYV7JNwhoA.JHlPg4iOkqbXmXjXwVdo)):has(.jD_TVjbjclUwewP7P9e8)");
+    return getQueueContainerElement();
 }
 
 export let isSpicySidebarMode = false;
@@ -84,13 +96,13 @@ export function OpenSidebarLyrics(wasOpenForceUndefined: boolean = false) {
     }
     const finalContainer = getQueueContainer();
     {
-        if (parentContainer.querySelector<HTMLElement>(':scope > *:not(#SpicyLyricsPage)')) {
+        if (getParentContainerChildren(parentContainer)) {
             onOpen_wasThingOpen = 
                     wasOpenForceUndefined
                         ? undefined
                     : getNowPlayingViewContainer()
                         ? "npv"
-                    : parentContainer.querySelector<HTMLElement>(".vzeIlCPBQJUaqdMZHqHE .vXYSi4u1nPutJ_ZkC6mq .jD_TVjbjclUwewP7P9e8")
+                    : getDevicesContainerElement()
                         ? "devices"
                     : finalContainer ? "queue" : undefined;
             

--- a/src/css/DynamicBG/spicy-dynamic-bg.css
+++ b/src/css/DynamicBG/spicy-dynamic-bg.css
@@ -56,11 +56,16 @@ aside video:hover {
 }
 
 .main-nowPlayingView-coverArtContainer :is(div, .E08D6ucrHuPJYzzGO7HG):has(video)::before,
-.main-nowPlayingView-coverArtContainer :is(div, .E08D6ucrHuPJYzzGO7HG):has(video)::after {
+.main-nowPlayingView-coverArtContainer :is(div, .E08D6ucrHuPJYzzGO7HG):has(video)::after,
+div.Of__Db4QgB9osz_mFxhw:has(video)::before,
+div.Of__Db4QgB9osz_mFxhw:has(video)::after,
+div.UUydeXMsXVZofB0YAOgm:has(.main-trackInfo-container)::before,
+div.UUydeXMsXVZofB0YAOgm:has(.main-trackInfo-container)::after {
   display: none;
 }
 
-aside:has(.spicy-dynamic-bg) .AAdBM1nhG73supMfnYX7 {
+aside:has(.spicy-dynamic-bg) .AAdBM1nhG73supMfnYX7,
+aside:has(.spicy-dynamic-bg) .iHa_q9pq4un3VNRQgwTx {
   z-index: 1;
   position: relative;
 }

--- a/src/css/Lyrics/Mixed.css
+++ b/src/css/Lyrics/Mixed.css
@@ -458,6 +458,10 @@ body.SpicySidebarLyrics__Active #SpicyLyricsPage.SpicyRenderer .LyricsContainer 
   --DefaultLyricsSize: clamp(0.8rem,calc(1cqw* 5), 2.5rem);
 }
 
+body.SpicySidebarLyrics__Active #SpicyLyricsPage.SpicyRenderer .LyricsContainer .SpicyLyricsScrollContainer[data-lyrics-type="Static"] {
+  --DefaultLyricsSize: clamp(0.9rem,calc(1cqw* 7), 2.8rem);
+}
+
 #SpicyLyricsPage.SpicyRenderer .LyricsContainer .SpicyLyricsScrollContainer[data-lyrics-type="Static"] .line {
   font-weight: 500;
 }

--- a/src/css/default.css
+++ b/src/css/default.css
@@ -330,7 +330,13 @@ body:not(:has(.Root__main-view-overlay .BeautifulLyricsPage:is(.Fullscreen))) #B
   z-index: -1;
 } */
 
-body.SpicySidebarLyrics__Active .Root__right-sidebar .XOawmCGZcQx4cesyNfVO >:not(#SpicyLyricsPage) {
+body.SpicySidebarLyrics__Active .eguwzH_QWTBXry7hiNj3:has([id="settings.showFriendActivity"]),
+body.SpicySidebarLyrics__Active .x-settings-row:has([id="settings.showFriendActivity"]) {
+  display: none !important;
+}
+
+body.SpicySidebarLyrics__Active .Root__right-sidebar .XOawmCGZcQx4cesyNfVO >:not(#SpicyLyricsPage),
+body.SpicySidebarLyrics__Active .Root__right-sidebar .oXO9_yYs6JyOwkBn8E4a >:not(#SpicyLyricsPage) {
   display: none !important;
 }
 

--- a/src/css/polyfills/tippy-polyfill.css
+++ b/src/css/polyfills/tippy-polyfill.css
@@ -1,0 +1,214 @@
+.main-contextMenu-tippy {
+  --generic-tooltip-background-color: var(--spice-card);
+  background-color: var(--generic-tooltip-background-color);
+  border-radius: 4px;
+  -webkit-box-shadow: 0 16px 24px rgba(var(--spice-rgb-shadow),.3),0 6px 8px rgba(var(--spice-rgb-shadow),.2);
+  box-shadow: 0 16px 24px rgba(var(--spice-rgb-shadow),.3),0 6px 8px rgba(var(--spice-rgb-shadow),.2);
+  color: var(--spice-text);
+  display: -webkit-box;
+  font-size: 14px!important;
+  max-width: 50ch;
+  overflow: hidden;
+  padding: 4px 8px;
+  text-overflow: ellipsis;
+  -webkit-line-clamp: 4;
+  line-clamp: 4;
+  -webkit-box-orient: vertical
+}
+
+.main-contextMenu-tippyEnter {
+  opacity: 0
+}
+
+.main-contextMenu-tippyEnterActive {
+  opacity: 1;
+  -webkit-transition: opacity .2s ease-in-out;
+  transition: opacity .2s ease-in-out
+}
+
+.tippy-box[data-animation=shift-toward-subtle][data-state=hidden] {
+  opacity: 0
+}
+
+.tippy-box[data-animation=shift-toward-subtle][data-state=hidden][data-placement^=top][data-state=hidden] {
+  -webkit-transform: translateY(-5px);
+  transform: translateY(-5px)
+}
+
+.tippy-box[data-animation=shift-toward-subtle][data-state=hidden][data-placement^=bottom][data-state=hidden] {
+  -webkit-transform: translateY(5px);
+  transform: translateY(5px)
+}
+
+.tippy-box[data-animation=shift-toward-subtle][data-state=hidden][data-placement^=left][data-state=hidden] {
+  -webkit-transform: translateX(-5px);
+  transform: translateX(-5px)
+}
+
+.tippy-box[data-animation=shift-toward-subtle][data-state=hidden][data-placement^=right][data-state=hidden] {
+  -webkit-transform: translateX(5px);
+  transform: translateX(5px)
+}
+
+.main-contextMenu-tippyWrapper {
+  display: inline-block
+}
+
+.tippy-box[data-theme~=activation][data-animation=fade][data-state=hidden] {
+  opacity: 0
+}
+
+[data-theme~=activation][data-tippy-root] {
+  max-width: calc(100vw - 10px);
+  z-index: 10
+}
+
+.tippy-box[data-theme~=activation] {
+  background-color: var(--background-elevated-base);
+  border-radius: 8px;
+  -webkit-box-shadow: 0 4px 40px rgba(var(--spice-rgb-shadow),.3);
+  box-shadow: 0 4px 40px rgba(var(--spice-rgb-shadow),.3);
+  color: var(--text-base);
+  font-size: 14px;
+  line-height: 1.4;
+  outline: 0;
+  position: relative;
+  text-align: start;
+  -webkit-transition-property: visibility,opacity,-webkit-transform;
+  transition-property: visibility,opacity,-webkit-transform;
+  transition-property: transform,visibility,opacity;
+  transition-property: transform,visibility,opacity,-webkit-transform
+}
+
+.tippy-box[data-theme~=activation]>.tippy-content {
+  padding: 16px;
+  position: relative
+}
+
+.tippy-box[data-theme~=activation][data-placement^=top]>.tippy-arrow {
+  bottom: 0
+}
+
+.tippy-box[data-theme~=activation][data-placement^=top]>.tippy-arrow:before {
+  border-top-color: initial;
+  border-width: 8px 8px 0;
+  bottom: -7px;
+  left: 0;
+  -webkit-transform-origin: center top;
+  transform-origin: center top
+}
+
+.tippy-box[data-theme~=activation][data-placement^=bottom]>.tippy-arrow {
+  top: 0
+}
+
+.tippy-box[data-theme~=activation][data-placement^=bottom]>.tippy-arrow:before {
+  border-bottom-color: initial;
+  border-width: 0 8px 8px;
+  left: 0;
+  top: -7px;
+  -webkit-transform-origin: center bottom;
+  transform-origin: center bottom
+}
+
+.tippy-box[data-theme~=activation][data-placement^=left]>.tippy-arrow {
+  right: 0
+}
+
+.tippy-box[data-theme~=activation][data-placement^=left]>.tippy-arrow:before {
+  border-left-color: initial;
+  border-width: 8px 0 8px 8px;
+  right: -7px;
+  -webkit-transform-origin: center left;
+  transform-origin: center left
+}
+
+.tippy-box[data-theme~=activation][data-placement^=right]>.tippy-arrow {
+  left: 0
+}
+
+.tippy-box[data-theme~=activation][data-placement^=right]>.tippy-arrow:before {
+  border-right-color: initial;
+  border-width: 8px 8px 8px 0;
+  left: -7px;
+  -webkit-transform-origin: center right;
+  transform-origin: center right
+}
+
+.tippy-box[data-theme~=activation][data-inertia][data-state=visible] {
+  -webkit-transition-timing-function: cubic-bezier(.54,1.5,.38,1.11);
+  transition-timing-function: cubic-bezier(.54,1.5,.38,1.11)
+}
+
+.tippy-arrow {
+  color: var(--background-elevated-base);
+  height: 16px;
+  pointer-events: none;
+  width: 16px
+}
+
+.tippy-arrow:before {
+  border-color: transparent;
+  border-style: solid;
+  content: "";
+  position: absolute
+}
+
+.ZEIqEgvTSLMYDUyg4fwD [data-tippy-root] {
+  width: 100%
+}
+
+.tippy-box[data-theme~=device-picker][data-animation=fade][data-state=hidden] {
+  opacity: 0
+}
+
+[data-theme~=device-picker][data-tippy-root] {
+  max-width: calc(100vw - 10px);
+  z-index: 10
+}
+
+.tippy-box[data-theme~=device-picker] {
+  background-color: var(--spice-card);
+  border-radius: 8px;
+  color: var(--spice-text);
+  outline: 0;
+  position: relative;
+  text-align: start;
+  -webkit-transition-property: visibility,opacity,-webkit-transform;
+  transition-property: visibility,opacity,-webkit-transform;
+  transition-property: transform,visibility,opacity;
+  transition-property: transform,visibility,opacity,-webkit-transform
+}
+
+.tippy-box[data-theme~=device-picker]>.tippy-content {
+  padding: 0;
+  position: relative
+}
+
+.tippy-box[data-theme~=device-picker]>.tippy-arrow {
+  color: var(--spice-card);
+  z-index: -1
+}
+
+.tippy-box[data-theme~=device-picker][data-placement^=top]>.tippy-arrow:before {
+  border-top-color: initial;
+  border-width: 14px;
+  bottom: -10px;
+  left: -6px;
+  -webkit-transform-origin: center top;
+  transform-origin: center top
+}
+
+.tippy-box[data-theme~=device-picker][data-inertia][data-state=visible] {
+  -webkit-transition-timing-function: cubic-bezier(.54,1.5,.38,1.11);
+  transition-timing-function: cubic-bezier(.54,1.5,.38,1.11)
+}
+
+.wRjmZh6e7KCL09qchtC9 .tippy-content {
+  background-color: var(--spice-card);
+  border-radius: 4px;
+  -webkit-box-shadow: 0 4px 12px 4px rgba(var(--spice-rgb-shadow),.5);
+  box-shadow: 0 4px 12px 4px rgba(var(--spice-rgb-shadow),.5);
+  min-width: 138px;
+  padding: 4px
+}

--- a/src/edited_packages/spcr-settings/settingsSection.tsx
+++ b/src/edited_packages/spcr-settings/settingsSection.tsx
@@ -182,8 +182,8 @@ class SettingsSection {
     this.setRerender = setRerender;
 
     return (
-      <div className="x-settings-section" key={rerender}>
-        <h2 className="TypeElement-cello-textBase-type">
+      <div className="x-settings-section YtAW7cQal8op8H9JkJ8T" key={rerender}>
+        <h2 className="TypeElement-cello-textBase-type e-91000-text encore-text-body-medium-bold encore-internal-color-text-base">
           {this.name}
         </h2>
         {Object.entries(this.settingsFields).map(([nameId, field]) => {
@@ -217,8 +217,8 @@ class SettingsSection {
     };
 
     return (
-      <div className="x-settings-row">
-        <div className="x-settings-firstColumn">
+      <div className="x-settings-row eguwzH_QWTBXry7hiNj3">
+        <div className="x-settings-firstColumn lfXDZUXLhhKhFPjDO8by">
           <label
             className="TypeElement-viola-textSubdued-type"
             htmlFor={id}
@@ -226,7 +226,7 @@ class SettingsSection {
             {props.field.description || ""}
           </label>
         </div>
-        <div className="x-settings-secondColumn">
+        <div className="x-settings-secondColumn jKCZodyn7H2Trr7dhvGm">
           {props.field.type === "input" ? (
             <input
               className="x-settings-input"
@@ -246,7 +246,7 @@ class SettingsSection {
             <span>
               <button
                 id={id}
-                className="Button-sc-y0gtbx-0 Button-small-buttonSecondary-useBrowserDefaultFocusStyle x-settings-button"
+                className="Button-sc-y0gtbx-0 Button-small-buttonSecondary-useBrowserDefaultFocusStyle Button-sc-y0gtbx-0 Button-buttonSecondary-small-useBrowserDefaultFocusStyle encore-text-body-small-bold e-91000-button--small l_pugTMA53sS_K65iEiW Button-buttonSecondary-small-isUsingKeyboard-useBrowserDefaultFocusStyle x-settings-button"
                 {...props.field.events}
                 onClick={(e) => {
                   setValue();
@@ -280,7 +280,7 @@ class SettingsSection {
             </label>
           ) : props.field.type === "dropdown" ? (
             <select
-              className="main-dropDown-dropDown"
+              className="main-dropDown-dropDown FQupgLGfMkp1dOYvUeuQ"
               id={id}
               {...props.field.events}
               onChange={(e) => {

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -1,9 +1,10 @@
 import storage from "./storage.ts";
 import Defaults from "../components/Global/Defaults.ts";
-import { LyricsStore } from "./Lyrics/fetchLyrics.ts";
+import fetchLyrics, { LyricsStore } from "./Lyrics/fetchLyrics.ts";
 import { SpotifyPlayer } from "../components/Global/SpotifyPlayer.ts";
-import { ShowNotification } from "../components/Pages/PageView.ts";
+import PageView, { ShowNotification } from "../components/Pages/PageView.ts";
 import { Spicetify } from "@spicetify/bundler";
+import ApplyLyrics from "./Lyrics/Global/Applyer.ts";
 
 export async function setSettingsMenu() {
 
@@ -30,6 +31,12 @@ function devSettings(SettingsSection: any) {
             await LyricsStore.RemoveItem(currentSongId ?? "");
             storage.set("currentLyricsData", null);
             ShowNotification(`Lyrics for the current song, have been removed from available all caches`, "success");
+            if (PageView.IsOpened) {
+                const uri = SpotifyPlayer.GetUri();
+                if (uri && uri !== undefined) {
+                    fetchLyrics(uri).then(ApplyLyrics);
+                }
+            }
         } catch (error) {
             ShowNotification(`
                 <p>Lyrics for the current song, couldn't be removed from all available caches</p>
@@ -43,6 +50,12 @@ function devSettings(SettingsSection: any) {
         try {
             await LyricsStore.Destroy();
             ShowNotification("The Lyrics Cache has been destroyed successfully", "success")
+            if (PageView.IsOpened) {
+                const uri = SpotifyPlayer.GetUri();
+                if (uri && uri !== undefined) {
+                    fetchLyrics(uri).then(ApplyLyrics);
+                }
+            }
         } catch (error) {
             ShowNotification(`
                 <p>The Lyrics cache, couldn't be removed</p>
@@ -56,6 +69,12 @@ function devSettings(SettingsSection: any) {
         try {
             storage.set("currentLyricsData", null);
             ShowNotification("Lyrics for the current song, have been removed from the internal state successfully", "success");
+            if (PageView.IsOpened) {
+                const uri = SpotifyPlayer.GetUri();
+                if (uri && uri !== undefined) {
+                    fetchLyrics(uri).then(ApplyLyrics);
+                }
+            }
         } catch (error) {
             ShowNotification(`
                 <p>Lyrics for the current song, couldn't be removed from the internal state</p>

--- a/tasks/config.ts
+++ b/tasks/config.ts
@@ -1,3 +1,3 @@
 export const ProjectName = "spicy-lyrics";
 
-export const ProjectVersion = "5.12.0";
+export const ProjectVersion = "5.12.5";


### PR DESCRIPTION
# 🚀 Update 5.12.5

- 🎶 **Spotify Compatibility**: Updated Spicy Lyrics to work with Spotify `1.2.72`
- 🛠️ **Polyfills Added**: Implemented polyfills for Tippy elements in Spotify `1.2.72`  
  - ✅ Also fixes Tippy issues in other extensions/themes
- 🔤 **UI Improvement**: Increased font size for *Static type lyrics* in Sidebar Mode
- 👥 **Sidebar Mode Tweak**: Friend activity option is now hidden while in Sidebar Mode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Lyrics now auto-refresh after clearing caches when the lyrics page is open.
- Bug Fixes
  - Improved reliability of opening Sidebar Lyrics across Now Playing, Queue, and Devices views.
  - Fixed dynamic background layering to prevent visual overlays; adjusted sidebar z-index.
- Style
  - New tooltip/menu styling and animations for context menus and device picker.
  - Increased Static lyrics font size inside the active sidebar for better readability.
  - Cleaned right-sidebar content (including Friend Activity settings) when lyrics are active.
  - Updated settings section styling for visual consistency.
- Chores
  - Bumped version to 5.12.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->