### PR TITLE
[Bugfix] Font Clipping for Custom Fonts

### DIFF
--- a/src/css/Lyrics/Mixed.css
+++ b/src/css/Lyrics/Mixed.css
@@ -190,6 +190,26 @@
 #SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line .letterGroup {
   --text-shadow-blur-radius: 4px;
   --text-shadow-opacity: 0%;
+  /* Extend compositing layer boundaries to cover italic/oblique glyph overhang.
+     GPU-composited layers are clipped to the element's layout box, which cuts off
+     slanted glyphs at the box edges — most visibly on the active (animated) line.
+     Padding extends the layer; negative margin cancels the layout impact. */
+  padding-inline: 0.3em;
+  margin-inline: -0.3em;
+  padding-block: 0.15em;
+  margin-block: -0.15em;
+}
+
+/* Fix for line-synced mode: extend GPU compositing layer to capture italic/oblique glyph overhang.
+   In data-lyrics-type="Line", the .line itself is the animated unit (scale transition).
+   Only padding-block is used here — no negative margin — because inter-line spacing already
+   comes from the explicit margin on .line and must not be overridden. */
+#SpicyLyricsPage.SpicyRenderer
+  .LyricsContainer
+  .LyricsContent
+  .SpicyLyricsScrollContainer[data-lyrics-type="Line"]
+  .line {
+  padding-block: 0.15em;
 }
 
 #SpicyLyricsPage.SpicyRenderer .LyricsContainer .LyricsContent .line:not(.musical-line) .word,
@@ -496,6 +516,10 @@
     scale 0.2s cubic-bezier(0.37, 0, 0.63, 1),
     opacity 0.2s cubic-bezier(0.37, 0, 0.63, 1) !important;
   margin: var(--SpicyLyrics-LineSpacing, 2cqw 0);
+  /* Counteract the padding-block added for italic glyph overhang (see earlier rule).
+     margin-block after margin: wins the cascade within this block. 1cqw matches
+     the block component of --SpicyLyrics-LineSpacing so text-to-text spacing is unchanged. */
+  margin-block: calc(1cqw - 0.15em);
   /*   text-shadow: 0 0 var(--text-shadow-blur-radius) rgba(255,255,255,var(--text-shadow-opacity)); */
 }
 

--- a/src/css/Lyrics/Mixed.css
+++ b/src/css/Lyrics/Mixed.css
@@ -208,7 +208,7 @@
   .LyricsContainer
   .LyricsContent
   .SpicyLyricsScrollContainer[data-lyrics-type="Line"]
-  .line {
+  .line:not(.musical-line) {
   padding-block: 0.15em;
 }
 

--- a/src/css/Lyrics/main.css
+++ b/src/css/Lyrics/main.css
@@ -4,7 +4,7 @@
   align-items: center;
   flex-direction: column;
   justify-content: center;
-  overflow: hidden;
+  overflow: visible;
   width: 100%;
   z-index: 4;
 }
@@ -23,7 +23,8 @@
   --Simplebar-Scrollbar-Color: rgba(255, 255, 255, 0.6);
   --vertical-gap: 0px;
 
-  overflow-x: hidden !important;
+  overflow-x: clip !important;
+  overflow-clip-margin: 200px;
   overflow-y: auto !important;
   height: calc(100% - var(--vertical-gap));
   width: 100%;


### PR DESCRIPTION
Before:
<img width="296" height="105" alt="image" src="https://github.com/user-attachments/assets/350d2b6d-720a-452e-99d5-af33a9e99437" />
After:
<img width="254" height="95" alt="image" src="https://github.com/user-attachments/assets/3405ae0e-4a5e-4e67-b1a6-1f79fe5e8054" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved rendering and spacing for italic/oblique lyrics to prevent visual clipping and preserve cascade/line spacing in line-synced mode.
  * Adjusted lyrics container overflow and clipping behavior to reveal content more reliably and provide a safer clipping margin for better readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->