### PR TITLE
[Feature] Persistent local TTML with management panel

### DIFF
--- a/src/components/Global/SpotifyPlayer.ts
+++ b/src/components/Global/SpotifyPlayer.ts
@@ -124,6 +124,14 @@ export type Artist = {
   uri: string;
 };
 
+export const TrackIdFromUri = (uri: string): string => {
+  // For local lyrics, use the part after "spotify:local:" as id
+  if (uri?.startsWith("spotify:local:")) {
+    return uri.substring("spotify:local:".length);
+  }
+  return uri?.split(":")[2];
+}
+
 export const SpotifyPlayer = {
   IsPlaying: false,
   _DEPRECATED_: {
@@ -181,7 +189,11 @@ export const SpotifyPlayer = {
     return Spicetify?.Player?.data?.item?.metadata?.album_title;
   },
   GetId: (): string | undefined => {
-    return Spicetify?.Player?.data?.item?.uri?.split(":")[2];
+    const uri = Spicetify?.Player?.data?.item?.uri;
+    return uri != null ? TrackIdFromUri(uri) : undefined;
+  },
+  IsLocalTrack: (): boolean | undefined => {
+    return Spicetify?.Player?.data?.item?.isLocal;
   },
   GetArtists: (): Artist[] | undefined => {
     return Spicetify?.Player?.data?.item?.artists as Artist[];

--- a/src/components/ReactComponents/Settings/LocalLyricsManager.tsx
+++ b/src/components/ReactComponents/Settings/LocalLyricsManager.tsx
@@ -1,0 +1,282 @@
+import { startTransition, useEffect, useState } from "react";
+import ReactDOM from "react-dom/client";
+
+import fetchLyrics from "../../../utils/Lyrics/fetchLyrics.ts";
+import ApplyLyrics from "../../../utils/Lyrics/Global/Applyer.ts";
+import {
+  clearLocalTTML,
+  getAllLocalLyricsRecords,
+  removeLocalTTML,
+  type LocalLyricsRecord,
+} from "../../../utils/Lyrics/LocalTTML.ts";
+import storage from "../../../utils/storage.ts";
+import { SpotifyPlayer } from "../../Global/SpotifyPlayer.ts";
+import { PopupModal } from "../../Modal.ts";
+import { ShowNotification } from "../../Pages/PageView.ts";
+
+const BUTTON_CLASS_NAME = "spicy-local-lyrics-manager__button encore-text-body-small-bold";
+
+async function refreshLyricsIfCurrentTrackWasRemoved(trackIds: string[]) {
+  const currentTrackId = SpotifyPlayer.GetId();
+  if (!currentTrackId || !trackIds.includes(currentTrackId)) {
+    return;
+  }
+
+  const uri = SpotifyPlayer.GetUri();
+  storage.set("currentLyricsData", "");
+
+  if (!uri) {
+    return;
+  }
+
+  try {
+    const lyrics = await fetchLyrics(uri);
+    ApplyLyrics(lyrics);
+  } catch (error) {
+    console.error("Error refreshing lyrics after removing a local TTML:", error);
+    ShowNotification("Removed local lyrics, but refreshing the page failed.", "warning", 5000);
+  }
+}
+
+function getDisplayTrackName(record: LocalLyricsRecord) {
+  return record.trackName?.trim() || "Unknown song";
+}
+
+function getDisplayArtistName(record: LocalLyricsRecord) {
+  return record.artistNames?.trim() || "Unknown artist";
+}
+
+export function openLocalLyricsManagerModal() {
+  const container = document.createElement("div");
+  container.className = "spicy-local-lyrics-manager__modal-root";
+  const reactRoot = ReactDOM.createRoot(container);
+
+  reactRoot.render(<LocalLyricsManager />);
+
+  PopupModal.display({
+    title: "Local Lyrics",
+    content: container,
+    isLarge: true,
+    onClose: () => {
+      reactRoot.unmount();
+    },
+  });
+}
+
+export default function LocalLyricsManager() {
+  const [records, setRecords] = useState<LocalLyricsRecord[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isWorking, setIsWorking] = useState(false);
+  const [pendingRemovalTrackId, setPendingRemovalTrackId] = useState<string | null>(null);
+  const [pendingClearAllStartedAt, setPendingClearAllStartedAt] = useState<number | null>(null);
+  const [clearAllCountdown, setClearAllCountdown] = useState(0);
+
+  const loadRecords = async () => {
+    setIsLoading(true);
+
+    try {
+      const nextRecords = await getAllLocalLyricsRecords();
+      startTransition(() => {
+        setRecords(nextRecords);
+      });
+    } catch (error) {
+      console.error("Error loading local TTML records:", error);
+      ShowNotification("Error loading saved local lyrics.", "error", 5000);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    void loadRecords();
+  }, []);
+
+  useEffect(() => {
+    if (!pendingRemovalTrackId) {
+      return;
+    }
+
+    const pendingRecordStillExists = records.some((record) => record.trackId === pendingRemovalTrackId);
+    if (!pendingRecordStillExists) {
+      setPendingRemovalTrackId(null);
+    }
+  }, [pendingRemovalTrackId, records]);
+
+  useEffect(() => {
+    if (!pendingRemovalTrackId || isWorking) {
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      setPendingRemovalTrackId((currentPendingTrackId) => {
+        return currentPendingTrackId === pendingRemovalTrackId ? null : currentPendingTrackId;
+      });
+    }, 3000);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [isWorking, pendingRemovalTrackId]);
+
+  useEffect(() => {
+    if (!pendingClearAllStartedAt) {
+      setClearAllCountdown(0);
+      return;
+    }
+
+    const readyAt = pendingClearAllStartedAt + 3000;
+
+    const tick = () => {
+      const remainingMs = readyAt - Date.now();
+      if (remainingMs <= 0) {
+        setClearAllCountdown(0);
+        return;
+      }
+
+      setClearAllCountdown(Math.ceil(remainingMs / 1000));
+    };
+
+    tick();
+    const intervalId = window.setInterval(tick, 200);
+    return () => window.clearInterval(intervalId);
+  }, [pendingClearAllStartedAt]);
+
+  const isClearAllArmed = pendingClearAllStartedAt !== null;
+  const isClearAllReady = isClearAllArmed && clearAllCountdown === 0;
+  const hasRecords = records.length > 0;
+
+  const handleDelete = async (record: LocalLyricsRecord) => {
+    if (pendingRemovalTrackId !== record.trackId) {
+      setPendingRemovalTrackId(record.trackId);
+      return;
+    }
+
+    setIsWorking(true);
+
+    try {
+      await removeLocalTTML(record.trackId);
+      setPendingRemovalTrackId(null);
+      await refreshLyricsIfCurrentTrackWasRemoved([record.trackId]);
+      await loadRecords();
+      ShowNotification("Local lyrics removed.", "success", 4000);
+    } catch (error) {
+      console.error("Error removing local TTML record:", error);
+      ShowNotification("Error removing local lyrics.", "error", 5000);
+    } finally {
+      setIsWorking(false);
+    }
+  };
+
+  const handleClearAll = async () => {
+    if (!records.length) {
+      return;
+    }
+
+    setIsWorking(true);
+
+    try {
+      const removedTrackIds = records.map((record) => record.trackId);
+      await clearLocalTTML();
+      setPendingClearAllStartedAt(null);
+      setPendingRemovalTrackId(null);
+      await refreshLyricsIfCurrentTrackWasRemoved(removedTrackIds);
+      await loadRecords();
+      ShowNotification("All local lyrics removed.", "success", 4000);
+    } catch (error) {
+      console.error("Error clearing local TTML records:", error);
+      ShowNotification("Error clearing local lyrics.", "error", 5000);
+    } finally {
+      setIsWorking(false);
+    }
+  };
+
+  const handleClearAllClick = () => {
+    if (!records.length || isWorking) {
+      return;
+    }
+
+    if (!isClearAllArmed) {
+      setPendingClearAllStartedAt(Date.now());
+      setClearAllCountdown(3);
+      return;
+    }
+
+    if (!isClearAllReady) {
+      return;
+    }
+
+    void handleClearAll();
+  };
+
+  return (
+    <div className="spicy-local-lyrics-manager slm slm--local-lyrics scroll-x-hidden">
+      <div className="spicy-local-lyrics-manager__toolbar">
+        <div className="spicy-local-lyrics-manager__summary">
+          <span className="spicy-local-lyrics-manager__count">
+            {isLoading
+              ? "Loading saved local lyrics..."
+              : `${records.length} saved local TTML${records.length === 1 ? "" : "s"}`}
+          </span>
+          <span className="spicy-local-lyrics-manager__hint">
+            Local TTML saved on this device appear here.
+          </span>
+        </div>
+        {hasRecords ? (
+          <div className="spicy-local-lyrics-manager__actions">
+            <button
+              className={`${BUTTON_CLASS_NAME} spicy-local-lyrics-manager__button--danger${
+                isClearAllArmed && !isClearAllReady
+                  ? " spicy-local-lyrics-manager__button--dangerPending"
+                  : ""
+              }`}
+              disabled={isLoading || isWorking || records.length === 0}
+              onClick={handleClearAllClick}
+              type="button"
+            >
+              {isWorking
+                ? "Clearing..."
+                : isClearAllReady
+                  ? "Click Again to Clear"
+                  : isClearAllArmed
+                    ? `Wait ${clearAllCountdown}s`
+                  : "Clear All"}
+            </button>
+          </div>
+        ) : null}
+      </div>
+
+      {!isLoading && !hasRecords ? (
+        <div className="spicy-local-lyrics-manager__empty">
+          No local lyrics have been saved yet.
+        </div>
+      ) : (
+        <div className="spicy-local-lyrics-manager__list" role="list">
+          {records.map((record) => {
+            return (
+              <div className="spicy-local-lyrics-manager__item" key={record.trackId} role="listitem">
+                <div className="spicy-local-lyrics-manager__item-text">
+                  <div className="spicy-local-lyrics-manager__title">
+                    {getDisplayTrackName(record)}
+                  </div>
+                  <div className="spicy-local-lyrics-manager__artist">
+                    {getDisplayArtistName(record)}
+                  </div>
+                </div>
+                <button
+                  className={`${BUTTON_CLASS_NAME} spicy-local-lyrics-manager__button--danger${
+                    pendingRemovalTrackId === record.trackId
+                      ? " spicy-local-lyrics-manager__button--dangerPending"
+                      : ""
+                  }`}
+                  disabled={isWorking}
+                  onClick={() => void handleDelete(record)}
+                  type="button"
+                >
+                  {pendingRemovalTrackId === record.trackId ? "Click Again" : "Remove"}
+                </button>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/ReactComponents/Settings/LocalLyricsManager.tsx
+++ b/src/components/ReactComponents/Settings/LocalLyricsManager.tsx
@@ -14,7 +14,8 @@ import { SpotifyPlayer } from "../../Global/SpotifyPlayer.ts";
 import { PopupModal } from "../../Modal.ts";
 import { ShowNotification } from "../../Pages/PageView.ts";
 
-const BUTTON_CLASS_NAME = "spicy-local-lyrics-manager__button encore-text-body-small-bold";
+const BUTTON_CLASS_NAME =
+  "spicy-local-lyrics-manager__button encore-text-body-small-bold";
 
 async function refreshLyricsIfCurrentTrackWasRemoved(trackIds: string[]) {
   const currentTrackId = SpotifyPlayer.GetId();
@@ -33,8 +34,15 @@ async function refreshLyricsIfCurrentTrackWasRemoved(trackIds: string[]) {
     const lyrics = await fetchLyrics(uri);
     ApplyLyrics(lyrics);
   } catch (error) {
-    console.error("Error refreshing lyrics after removing a local TTML:", error);
-    ShowNotification("Removed local lyrics, but refreshing the page failed.", "warning", 5000);
+    console.error(
+      "Error refreshing lyrics after removing a local TTML:",
+      error,
+    );
+    ShowNotification(
+      "Removed local lyrics, but refreshing the page failed.",
+      "warning",
+      5000,
+    );
   }
 }
 
@@ -44,6 +52,10 @@ function getDisplayTrackName(record: LocalLyricsRecord) {
 
 function getDisplayArtistName(record: LocalLyricsRecord) {
   return record.artistNames?.trim() || "Unknown artist";
+}
+
+function getTrackTypeLabel(record: LocalLyricsRecord) {
+  return record.isLocal ? "Local" : "Spotify";
 }
 
 export function openLocalLyricsManagerModal() {
@@ -67,8 +79,12 @@ export default function LocalLyricsManager() {
   const [records, setRecords] = useState<LocalLyricsRecord[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [isWorking, setIsWorking] = useState(false);
-  const [pendingRemovalTrackId, setPendingRemovalTrackId] = useState<string | null>(null);
-  const [pendingClearAllStartedAt, setPendingClearAllStartedAt] = useState<number | null>(null);
+  const [pendingRemovalTrackId, setPendingRemovalTrackId] = useState<
+    string | null
+  >(null);
+  const [pendingClearAllStartedAt, setPendingClearAllStartedAt] = useState<
+    number | null
+  >(null);
   const [clearAllCountdown, setClearAllCountdown] = useState(0);
 
   const loadRecords = async () => {
@@ -96,7 +112,9 @@ export default function LocalLyricsManager() {
       return;
     }
 
-    const pendingRecordStillExists = records.some((record) => record.trackId === pendingRemovalTrackId);
+    const pendingRecordStillExists = records.some(
+      (record) => record.trackId === pendingRemovalTrackId,
+    );
     if (!pendingRecordStillExists) {
       setPendingRemovalTrackId(null);
     }
@@ -109,7 +127,9 @@ export default function LocalLyricsManager() {
 
     const timeoutId = window.setTimeout(() => {
       setPendingRemovalTrackId((currentPendingTrackId) => {
-        return currentPendingTrackId === pendingRemovalTrackId ? null : currentPendingTrackId;
+        return currentPendingTrackId === pendingRemovalTrackId
+          ? null
+          : currentPendingTrackId;
       });
     }, 3000);
 
@@ -237,7 +257,7 @@ export default function LocalLyricsManager() {
                   ? "Click Again to Clear"
                   : isClearAllArmed
                     ? `Wait ${clearAllCountdown}s`
-                  : "Clear All"}
+                    : "Clear All"}
             </button>
           </div>
         ) : null}
@@ -251,10 +271,23 @@ export default function LocalLyricsManager() {
         <div className="spicy-local-lyrics-manager__list" role="list">
           {records.map((record) => {
             return (
-              <div className="spicy-local-lyrics-manager__item" key={record.trackId} role="listitem">
+              <div
+                className="spicy-local-lyrics-manager__item"
+                key={record.trackId}
+                role="listitem"
+              >
                 <div className="spicy-local-lyrics-manager__item-text">
-                  <div className="spicy-local-lyrics-manager__title">
-                    {getDisplayTrackName(record)}
+                  <div className="spicy-local-lyrics-manager__title-row">
+                    <div className="spicy-local-lyrics-manager__title">
+                      {getDisplayTrackName(record)}
+                    </div>
+                    {record.isLocal && (
+                      <div className="spicy-local-lyrics-manager__badges">
+                        <span className="spicy-local-lyrics-manager__badge">
+                          {getTrackTypeLabel(record)}
+                        </span>
+                      </div>
+                    )}
                   </div>
                   <div className="spicy-local-lyrics-manager__artist">
                     {getDisplayArtistName(record)}
@@ -270,7 +303,9 @@ export default function LocalLyricsManager() {
                   onClick={() => void handleDelete(record)}
                   type="button"
                 >
-                  {pendingRemovalTrackId === record.trackId ? "Click Again" : "Remove"}
+                  {pendingRemovalTrackId === record.trackId
+                    ? "Click Again"
+                    : "Remove"}
                 </button>
               </div>
             );

--- a/src/components/Utils/GlobalExecute.ts
+++ b/src/components/Utils/GlobalExecute.ts
@@ -1,13 +1,14 @@
 import { Query } from "../../utils/API/Query.ts";
 import fetchLyrics from "../../utils/Lyrics/fetchLyrics.ts";
 import ApplyLyrics from "../../utils/Lyrics/Global/Applyer.ts";
+import { removeLocalTTML, saveLocalTTML } from "../../utils/Lyrics/LocalTTML.ts";
 import { ProcessLyrics } from "../../utils/Lyrics/ProcessLyrics.ts";
 import storage from "../../utils/storage.ts";
 import Global from "../Global/Global.ts";
 import { SpotifyPlayer } from "../Global/SpotifyPlayer.ts";
 import { ShowNotification } from "../Pages/PageView.ts";
 
-Global.SetScope("execute", (command: string) => {
+Global.SetScope("execute", async (command: string) => {
   switch (command) {
     case "upload-ttml": {
       // console.log("Upload TTML");
@@ -22,33 +23,47 @@ Global.SetScope("execute", (command: string) => {
             const uri = SpotifyPlayer.GetUri();
 
             if (uri.startsWith("spotify:local:")) {
-              ShowNotification("Local TTML files are not available on local songs", "warning", 5000);
-              return
-            };
-
+              ShowNotification(
+                "Local TTML files are not available on local songs",
+                "warning",
+                5000
+              );
+              return;
+            }
 
             const ttml = e.target?.result as string;
             ShowNotification("Found TTML, Parsing...", "info", 5000);
             ParseTTML(ttml).then(async (result) => {
+              if (!result?.Result) {
+                ShowNotification("Unable to parse TTML file.", "error", 5000);
+                return;
+              }
+
+              const trackId = SpotifyPlayer.GetId();
               const dataToSave = {
                 ...result?.Result,
-                id: SpotifyPlayer.GetId(),
+                id: trackId,
               };
 
-              await ProcessLyrics(dataToSave);
-
-              storage.set("currentLyricsData", JSON.stringify(dataToSave));
-              setTimeout(() => {
-                fetchLyrics(uri ?? "")
-                  .then((lyrics) => {
-                    ApplyLyrics(lyrics);
-                    ShowNotification("Lyrics Parsed and Applied!", "success", 5000);
-                  })
-                  .catch((err) => {
-                    ShowNotification("Error applying lyrics", "error", 5000);
-                    console.error("Error applying lyrics:", err);
-                  });
-              }, 25);
+              try {
+                await ProcessLyrics(dataToSave);
+                await saveLocalTTML(trackId ?? "", dataToSave);
+                storage.set("currentLyricsData", JSON.stringify(dataToSave));
+                setTimeout(() => {
+                  fetchLyrics(uri ?? "")
+                    .then((lyrics) => {
+                      ApplyLyrics(lyrics);
+                      ShowNotification("Lyrics Parsed and Applied!", "success", 5000);
+                    })
+                    .catch((err) => {
+                      ShowNotification("Error applying lyrics", "error", 5000);
+                      console.error("Error applying lyrics:", err);
+                    });
+                }, 25);
+              } catch (error) {
+                console.error("Error saving local TTML:", error);
+                ShowNotification("Error saving local TTML.", "error", 5000);
+              }
             });
           };
           reader.onerror = (e) => {
@@ -61,19 +76,26 @@ Global.SetScope("execute", (command: string) => {
       fileInput.click();
       break;
     }
-    case "reset-ttml":
+    case "reset-ttml": {
       // console.log("Reset TTML");
+      try {
+        await removeLocalTTML(SpotifyPlayer.GetId() ?? "");
+      } catch (error) {
+        console.error("Error removing local TTML:", error);
+        ShowNotification("Error resetting local TTML.", "error", 5000);
+      }
       storage.set("currentLyricsData", "");
       ShowNotification("TTML has been reset.", "info", 5000);
-      setTimeout(() => {
-        fetchLyrics(SpotifyPlayer.GetUri() ?? "")
-          .then(ApplyLyrics)
-          .catch((err) => {
-            ShowNotification("Error applying lyrics", "error", 5000);
-            console.error("Error applying lyrics:", err);
-          });
-      }, 25);
+      await new Promise(resolve => setTimeout(resolve, 25));
+      try {
+        const lyrics = await fetchLyrics(SpotifyPlayer.GetUri() ?? "");
+        ApplyLyrics(lyrics);
+      } catch (err) {
+        ShowNotification("Error applying lyrics", "error", 5000);
+        console.error("Error applying lyrics:", err);
+      }
       break;
+    }
   }
 });
 

--- a/src/components/Utils/GlobalExecute.ts
+++ b/src/components/Utils/GlobalExecute.ts
@@ -47,7 +47,20 @@ Global.SetScope("execute", async (command: string) => {
 
               try {
                 await ProcessLyrics(dataToSave);
-                await saveLocalTTML(trackId ?? "", dataToSave);
+                
+                if (trackId) {
+                  await saveLocalTTML(trackId, dataToSave, {
+                    trackName: SpotifyPlayer.GetName() || null,
+                    artistNames:
+                      SpotifyPlayer.GetArtists()
+                        ?.map((artist) => artist.name)
+                        .filter(Boolean)
+                        .join(", ") || null,
+                  });
+                } else {
+                  ShowNotification("Unable to save lyrics without a track ID.", "warning", 5000);
+                }
+
                 storage.set("currentLyricsData", JSON.stringify(dataToSave));
                 setTimeout(() => {
                   fetchLyrics(uri ?? "")
@@ -79,14 +92,15 @@ Global.SetScope("execute", async (command: string) => {
     case "reset-ttml": {
       // console.log("Reset TTML");
       try {
+        storage.set("currentLyricsData", "");
         await removeLocalTTML(SpotifyPlayer.GetId() ?? "");
+        ShowNotification("TTML has been reset.", "info", 5000);
       } catch (error) {
         console.error("Error removing local TTML:", error);
         ShowNotification("Error resetting local TTML.", "error", 5000);
       }
-      storage.set("currentLyricsData", "");
-      ShowNotification("TTML has been reset.", "info", 5000);
-      await new Promise(resolve => setTimeout(resolve, 25));
+
+      await new Promise((resolve) => setTimeout(resolve, 25));
       try {
         const lyrics = await fetchLyrics(SpotifyPlayer.GetUri() ?? "");
         ApplyLyrics(lyrics);

--- a/src/components/Utils/GlobalExecute.ts
+++ b/src/components/Utils/GlobalExecute.ts
@@ -21,16 +21,6 @@ Global.SetScope("execute", async (command: string) => {
           const reader = new FileReader();
           reader.onload = async (e) => {
             const uri = SpotifyPlayer.GetUri();
-
-            if (uri.startsWith("spotify:local:")) {
-              ShowNotification(
-                "Local TTML files are not available on local songs",
-                "warning",
-                5000
-              );
-              return;
-            }
-
             const ttml = e.target?.result as string;
             ShowNotification("Found TTML, Parsing...", "info", 5000);
             ParseTTML(ttml).then(async (result) => {
@@ -50,6 +40,7 @@ Global.SetScope("execute", async (command: string) => {
                 
                 if (trackId) {
                   await saveLocalTTML(trackId, dataToSave, {
+                    isLocal: SpotifyPlayer.IsLocalTrack(),
                     trackName: SpotifyPlayer.GetName() || null,
                     artistNames:
                       SpotifyPlayer.GetArtists()

--- a/src/css/default.scss
+++ b/src/css/default.scss
@@ -296,11 +296,45 @@ body.sl_settings_top {
     width: 100%;
   }
 
+  &__title-row {
+    align-items: center;
+    column-gap: 8px;
+    display: flex;
+    flex-wrap: wrap;
+    min-width: 0;
+    row-gap: 6px;
+  }
+
+  &__badges {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    max-width: 100%;
+    min-width: 0;
+  }
+
+  &__badge {
+    align-items: center;
+    background: rgba(255, 255, 255, 0.08);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 999px;
+    color: var(--spice-subtext);
+    display: inline-flex;
+    font-size: 0.72rem;
+    font-weight: 700;
+    letter-spacing: 0.02em;
+    min-height: 22px;
+    padding: 0 10px;
+    text-transform: uppercase;
+  }
+
   &__title {
     color: var(--spice-text);
+    flex: 0 1 auto;
     font-size: 0.98rem;
     font-weight: 700;
     line-height: 1.3;
+    min-width: 0;
     word-break: break-word;
   }
 

--- a/src/css/default.scss
+++ b/src/css/default.scss
@@ -157,6 +157,243 @@ body.sl_settings_top {
   border-radius: 8px;
 }
 
+.spicy-local-lyrics-manager {
+  align-self: stretch;
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  gap: 12px;
+  min-height: 0;
+  width: 100%;
+
+  &__toolbar {
+    align-items: center;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    justify-content: space-between;
+  }
+
+  &__summary {
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    gap: 4px;
+    min-width: 240px;
+  }
+
+  &__count {
+    color: var(--spice-text);
+    font-size: 0.95rem;
+    font-weight: 700;
+  }
+
+  &__hint,
+  &__meta,
+  &__track-id {
+    color: var(--spice-subtext);
+    font-size: 0.84rem;
+  }
+
+  &__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    justify-content: flex-end;
+  }
+
+  &__button {
+    align-items: center;
+    background: rgba(255, 255, 255, 0.08);
+    border: 1px solid rgba(255, 255, 255, 0.14);
+    border-radius: 999px;
+    color: var(--spice-text);
+    cursor: pointer;
+    display: inline-flex;
+    gap: 8px;
+    justify-content: center;
+    min-height: 32px;
+    padding: 0 14px;
+    transition:
+      background-color 120ms ease,
+      border-color 120ms ease,
+      opacity 120ms ease;
+
+    &:hover:not(:disabled) {
+      background: rgba(255, 255, 255, 0.14);
+      border-color: rgba(255, 255, 255, 0.22);
+    }
+
+    &:disabled {
+      cursor: not-allowed;
+      opacity: 0.55;
+    }
+  }
+
+  &__button--danger {
+    background: rgba(221, 78, 88, 0.12);
+    border-color: rgba(221, 78, 88, 0.28);
+
+    &:hover:not(:disabled) {
+      background: rgba(221, 78, 88, 0.18);
+      border-color: rgba(221, 78, 88, 0.4);
+    }
+  }
+
+  &__button--dangerPending {
+    background: rgba(255, 167, 38, 0.16);
+    border-color: rgba(255, 167, 38, 0.42);
+
+    &:hover:not(:disabled) {
+      background: rgba(255, 167, 38, 0.24);
+      border-color: rgba(255, 167, 38, 0.54);
+    }
+  }
+
+  &__list {
+    align-content: start;
+    display: grid;
+    flex: 1;
+    gap: 12px;
+    grid-template-columns: repeat(auto-fill, minmax(min(320px, 100%), 1fr));
+    min-height: 0;
+    overflow-y: auto;
+    padding-right: 4px;
+    width: 100%;
+  }
+
+  &__empty {
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px dashed rgba(255, 255, 255, 0.12);
+    border-radius: 12px;
+    box-sizing: border-box;
+    color: var(--spice-subtext);
+    grid-column: 1 / -1;
+    padding: 18px;
+    width: 100%;
+  }
+
+  &__item {
+    align-items: center;
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 12px;
+    box-sizing: border-box;
+    column-gap: 16px;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    justify-items: stretch;
+    padding: 14px;
+    width: 100%;
+  }
+
+  &__item-text {
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    gap: 4px;
+    min-width: 0;
+    width: 100%;
+  }
+
+  &__title {
+    color: var(--spice-text);
+    font-size: 0.98rem;
+    font-weight: 700;
+    line-height: 1.3;
+    word-break: break-word;
+  }
+
+  &__artist {
+    color: var(--spice-text);
+    font-size: 0.9rem;
+    opacity: 0.86;
+    word-break: break-word;
+  }
+
+  &__track-id {
+    font-family: var(--encore-body-font-stack, monospace);
+    word-break: break-all;
+  }
+
+  &__item .spicy-local-lyrics-manager__button {
+    align-self: center;
+    margin-top: 0;
+  }
+}
+
+.spicy-local-lyrics-manager__modal-root {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  min-width: 0;
+  width: 100%;
+}
+
+.main-embedWidgetGenerator-container:has(.spicy-local-lyrics-manager),
+.GenericModal:has(.spicy-local-lyrics-manager) .main-embedWidgetGenerator-container {
+  height: min(78vh, 920px);
+  max-height: 78vh;
+  max-width: 70vw;
+  width: min(70vw, 1280px);
+}
+
+.main-trackCreditsModal-mainSection:has(.spicy-local-lyrics-manager) {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.main-trackCreditsModal-originalCredits:has(.spicy-local-lyrics-manager) {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  min-width: 0;
+  padding-bottom: 0;
+  width: 100%;
+}
+
+@media (max-width: 1100px) {
+  .main-embedWidgetGenerator-container:has(.spicy-local-lyrics-manager),
+  .GenericModal:has(.spicy-local-lyrics-manager) .main-embedWidgetGenerator-container {
+    max-width: 84vw;
+    width: 84vw;
+  }
+}
+
+@media (max-width: 720px) {
+  .main-embedWidgetGenerator-container:has(.spicy-local-lyrics-manager),
+  .GenericModal:has(.spicy-local-lyrics-manager) .main-embedWidgetGenerator-container {
+    height: min(84vh, 920px);
+    max-height: 84vh;
+    max-width: 94vw;
+    width: 94vw;
+  }
+
+  .spicy-local-lyrics-manager__actions {
+    width: 100%;
+  }
+
+  .spicy-local-lyrics-manager__button {
+    flex: 1;
+  }
+
+  .spicy-local-lyrics-manager__list {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .spicy-local-lyrics-manager__item .spicy-local-lyrics-manager__button {
+    align-self: stretch;
+  }
+
+  .spicy-local-lyrics-manager__item {
+    align-items: stretch;
+    grid-template-columns: 1fr;
+    row-gap: 12px;
+  }
+}
+
 
 /* Take the elapsed time out of normal layout flow to avoid document-wide reflow
  * when the text updates every second. The progress bar is offset manually to

--- a/src/utils/Lyrics/LocalTTML.ts
+++ b/src/utils/Lyrics/LocalTTML.ts
@@ -1,0 +1,101 @@
+const LOCAL_TTML_DATABASE_NAME = "SpicyLyricsLocalTTML";
+const LOCAL_TTML_STORE_NAME = "lyrics";
+const LOCAL_TTML_DATABASE_VERSION = 1;
+
+let localTTMLDatabasePromise: Promise<IDBDatabase> | null = null;
+
+function requestToPromise<T>(request: IDBRequest<T>) {
+  return new Promise<T>((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () =>
+      reject(request.error ?? new Error("IndexedDB request failed."));
+  });
+}
+
+function transactionToPromise(transaction: IDBTransaction) {
+  return new Promise<void>((resolve, reject) => {
+    transaction.oncomplete = () => resolve();
+    transaction.onerror = () =>
+      reject(transaction.error ?? new Error("IndexedDB transaction failed."));
+    transaction.onabort = () =>
+      reject(transaction.error ?? new Error("IndexedDB transaction was aborted."));
+  });
+}
+
+function getLocalTTMLDatabase() {
+  if (!localTTMLDatabasePromise) {
+    localTTMLDatabasePromise = new Promise((resolve, reject) => {
+      const request = indexedDB.open(
+        LOCAL_TTML_DATABASE_NAME,
+        LOCAL_TTML_DATABASE_VERSION
+      );
+
+      request.onupgradeneeded = () => {
+        const database = request.result;
+        if (!database.objectStoreNames.contains(LOCAL_TTML_STORE_NAME)) {
+          database.createObjectStore(LOCAL_TTML_STORE_NAME);
+        }
+      };
+
+      request.onsuccess = () => {
+        const database = request.result;
+        database.onversionchange = () => {
+          database.close();
+          localTTMLDatabasePromise = null;
+        };
+        resolve(database);
+      };
+
+      request.onerror = () =>
+        reject(request.error ?? new Error("Unable to open IndexedDB."));
+    });
+  }
+
+  return localTTMLDatabasePromise;
+}
+
+/** 
+ * Get a local TTML for a specific track
+ * @param trackId The ID of the track
+ * @returns The local TTML object or null if not found
+ */
+export async function getLocalTTML(trackId: string): Promise<any | null> {
+  if (!trackId) return null;
+
+  const database = await getLocalTTMLDatabase();
+  const transaction = database.transaction(LOCAL_TTML_STORE_NAME, "readonly");
+  const store = transaction.objectStore(LOCAL_TTML_STORE_NAME);
+  return (await requestToPromise(store.get(trackId))) ?? null;
+}
+
+/** 
+ * Save a local TTML for a specific track
+ * @param trackId The ID of the track
+ * @param lyrics The TTML lyrics object to save
+ */
+export async function saveLocalTTML(trackId: string, lyrics: object): Promise<void> {
+  if (!trackId) return;
+
+  const database = await getLocalTTMLDatabase();
+  const transaction = database.transaction(LOCAL_TTML_STORE_NAME, "readwrite");
+  const store = transaction.objectStore(LOCAL_TTML_STORE_NAME);
+
+  store.put(lyrics, trackId);
+  await transactionToPromise(transaction);
+}
+
+/** 
+ * Remove a local TTML for a specific track
+ * @param trackId The ID of the track
+ */
+export async function removeLocalTTML(trackId: string): Promise<void> {
+  if (!trackId) return;
+
+  const database = await getLocalTTMLDatabase();
+  const transaction = database.transaction(LOCAL_TTML_STORE_NAME, "readwrite");
+  const store = transaction.objectStore(LOCAL_TTML_STORE_NAME);
+
+  store.delete(trackId);
+  await transactionToPromise(transaction);
+}
+

--- a/src/utils/Lyrics/LocalTTML.ts
+++ b/src/utils/Lyrics/LocalTTML.ts
@@ -11,14 +11,14 @@ type LyricsSource = (typeof LYRICS_SOURCE)[keyof typeof LYRICS_SOURCE];
 
 export type LocalLyricsRecord = {
   trackId: string;
-  trackName?: string;
-  artistNames?: string;
   lyrics: object;
   source: LyricsSource;
   addedAt: string;
-};
+} & LocalLyricsMetadata;
 
 type LocalLyricsMetadata = {
+  trackUri?: string;
+  isLocal?: boolean;
   trackName?: string;
   artistNames?: string;
 };
@@ -116,7 +116,7 @@ export async function getAllLocalLyricsRecords(): Promise<LocalLyricsRecord[]> {
 
 /**
  * Save a local TTML for a specific track.
- * @param trackId The ID of the track.
+ * @param trackId The ID of the track. Should be unique for each track.
  * @param lyrics The TTML lyrics object to save.
  * @param metadata Optional metadata about the lyrics (e.g., track name, artist names).
  */
@@ -134,11 +134,10 @@ export async function saveLocalTTML(
 
   const record: LocalLyricsRecord = {
     trackId,
-    trackName: metadata.trackName,
-    artistNames: metadata.artistNames,
     lyrics,
     source: LYRICS_SOURCE.USER_UPLOAD,
     addedAt: now,
+    ...metadata
   };
 
   store.put(record);

--- a/src/utils/Lyrics/LocalTTML.ts
+++ b/src/utils/Lyrics/LocalTTML.ts
@@ -7,13 +7,20 @@ const LYRICS_SOURCE = {
   /** User locally uploaded lyrics via dev tools */
   USER_UPLOAD: "user_upload",
 } as const;
-type LyricsSource = typeof LYRICS_SOURCE[keyof typeof LYRICS_SOURCE];
+type LyricsSource = (typeof LYRICS_SOURCE)[keyof typeof LYRICS_SOURCE];
 
-type LocalLyricsRecord = {
+export type LocalLyricsRecord = {
   trackId: string;
+  trackName?: string;
+  artistNames?: string;
   lyrics: object;
   source: LyricsSource;
   addedAt: string;
+};
+
+type LocalLyricsMetadata = {
+  trackName?: string;
+  artistNames?: string;
 };
 
 let localDatabasePromise: Promise<IDBDatabase> | null = null;
@@ -21,8 +28,7 @@ let localDatabasePromise: Promise<IDBDatabase> | null = null;
 function requestToPromise<T>(request: IDBRequest<T>) {
   return new Promise<T>((resolve, reject) => {
     request.onsuccess = () => resolve(request.result);
-    request.onerror = () =>
-      reject(request.error ?? new Error("IndexedDB request failed."));
+    request.onerror = () => reject(request.error ?? new Error("IndexedDB request failed."));
   });
 }
 
@@ -50,6 +56,10 @@ function getLocalDatabase() {
         }
       };
 
+      request.onblocked = () => {
+        reject(new Error("IndexedDB is blocked by another connection."));
+      };
+
       request.onsuccess = () => {
         const database = request.result;
         database.onversionchange = () => {
@@ -59,8 +69,7 @@ function getLocalDatabase() {
         resolve(database);
       };
 
-      request.onerror = () =>
-        reject(request.error ?? new Error("Unable to open IndexedDB."));
+      request.onerror = () => reject(request.error ?? new Error("Unable to open IndexedDB."));
     });
   }
 
@@ -86,12 +95,27 @@ export async function getLocalTTML(trackId: string): Promise<object | null> {
   return record?.lyrics ?? null;
 }
 
+export async function getAllLocalLyricsRecords(): Promise<LocalLyricsRecord[]> {
+  const database = await getLocalDatabase();
+  const transaction = database.transaction(LOCAL_LYRICS_STORE_NAME, "readonly");
+  const store = transaction.objectStore(LOCAL_LYRICS_STORE_NAME);
+  const records = (await requestToPromise(store.getAll())) ?? [];
+
+  return records.sort((first, second) => {
+    return new Date(second.addedAt ?? 0).getTime() - new Date(first.addedAt ?? 0).getTime();
+  });
+}
+
 /**
  * Save a local TTML for a specific track.
  * @param trackId The ID of the track.
  * @param lyrics The TTML lyrics object to save.
  */
-export async function saveLocalTTML(trackId: string, lyrics: object): Promise<void> {
+export async function saveLocalTTML(
+  trackId: string,
+  lyrics: object,
+  metadata: LocalLyricsMetadata = {}
+): Promise<void> {
   if (!trackId) return;
 
   const now = new Date().toISOString();
@@ -101,6 +125,8 @@ export async function saveLocalTTML(trackId: string, lyrics: object): Promise<vo
 
   const record: LocalLyricsRecord = {
     trackId,
+    trackName: metadata.trackName,
+    artistNames: metadata.artistNames,
     lyrics,
     source: LYRICS_SOURCE.USER_UPLOAD,
     addedAt: now,
@@ -125,3 +151,11 @@ export async function removeLocalTTML(trackId: string): Promise<void> {
   await transactionToPromise(transaction);
 }
 
+export async function clearLocalTTML(): Promise<void> {
+  const database = await getLocalDatabase();
+  const transaction = database.transaction(LOCAL_LYRICS_STORE_NAME, "readwrite");
+  const store = transaction.objectStore(LOCAL_LYRICS_STORE_NAME);
+
+  store.clear();
+  await transactionToPromise(transaction);
+}

--- a/src/utils/Lyrics/LocalTTML.ts
+++ b/src/utils/Lyrics/LocalTTML.ts
@@ -95,6 +95,10 @@ export async function getLocalTTML(trackId: string): Promise<object | null> {
   return record?.lyrics ?? null;
 }
 
+/**
+ * Get all local TTML records.
+ * @returns An array of all local TTML records.
+ */
 export async function getAllLocalLyricsRecords(): Promise<LocalLyricsRecord[]> {
   const database = await getLocalDatabase();
   const transaction = database.transaction(LOCAL_LYRICS_STORE_NAME, "readonly");
@@ -110,6 +114,7 @@ export async function getAllLocalLyricsRecords(): Promise<LocalLyricsRecord[]> {
  * Save a local TTML for a specific track.
  * @param trackId The ID of the track.
  * @param lyrics The TTML lyrics object to save.
+ * @param metadata Optional metadata about the lyrics (e.g., track name, artist names).
  */
 export async function saveLocalTTML(
   trackId: string,
@@ -151,6 +156,9 @@ export async function removeLocalTTML(trackId: string): Promise<void> {
   await transactionToPromise(transaction);
 }
 
+/**
+ * Clear all local TTML records.
+ */
 export async function clearLocalTTML(): Promise<void> {
   const database = await getLocalDatabase();
   const transaction = database.transaction(LOCAL_LYRICS_STORE_NAME, "readwrite");

--- a/src/utils/Lyrics/LocalTTML.ts
+++ b/src/utils/Lyrics/LocalTTML.ts
@@ -57,6 +57,7 @@ function getLocalDatabase() {
       };
 
       request.onblocked = () => {
+        localDatabasePromise = null;
         reject(new Error("IndexedDB is blocked by another connection."));
       };
 
@@ -69,7 +70,10 @@ function getLocalDatabase() {
         resolve(database);
       };
 
-      request.onerror = () => reject(request.error ?? new Error("Unable to open IndexedDB."));
+      request.onerror = () => {
+        localDatabasePromise = null;
+        reject(request.error ?? new Error("Unable to open IndexedDB."));
+      };
     });
   }
 

--- a/src/utils/Lyrics/LocalTTML.ts
+++ b/src/utils/Lyrics/LocalTTML.ts
@@ -1,8 +1,22 @@
-const LOCAL_TTML_DATABASE_NAME = "SpicyLyricsLocalTTML";
-const LOCAL_TTML_STORE_NAME = "lyrics";
-const LOCAL_TTML_DATABASE_VERSION = 1;
+const LOCAL_DATABASE_NAME = "SpicyLyricsLocalDB";
+const LOCAL_DATABASE_VERSION = 1;
+const LOCAL_LYRICS_STORE_NAME = "lyrics";
 
-let localTTMLDatabasePromise: Promise<IDBDatabase> | null = null;
+// One source for now, but can be expanded in the future if needed
+const LYRICS_SOURCE = {
+  /** User locally uploaded lyrics via dev tools */
+  USER_UPLOAD: "user_upload",
+} as const;
+type LyricsSource = typeof LYRICS_SOURCE[keyof typeof LYRICS_SOURCE];
+
+type LocalLyricsRecord = {
+  trackId: string;
+  lyrics: object;
+  source: LyricsSource;
+  addedAt: string;
+};
+
+let localDatabasePromise: Promise<IDBDatabase> | null = null;
 
 function requestToPromise<T>(request: IDBRequest<T>) {
   return new Promise<T>((resolve, reject) => {
@@ -22,18 +36,17 @@ function transactionToPromise(transaction: IDBTransaction) {
   });
 }
 
-function getLocalTTMLDatabase() {
-  if (!localTTMLDatabasePromise) {
-    localTTMLDatabasePromise = new Promise((resolve, reject) => {
-      const request = indexedDB.open(
-        LOCAL_TTML_DATABASE_NAME,
-        LOCAL_TTML_DATABASE_VERSION
-      );
+function getLocalDatabase() {
+  if (!localDatabasePromise) {
+    localDatabasePromise = new Promise((resolve, reject) => {
+      const request = indexedDB.open(LOCAL_DATABASE_NAME, LOCAL_DATABASE_VERSION);
 
       request.onupgradeneeded = () => {
         const database = request.result;
-        if (!database.objectStoreNames.contains(LOCAL_TTML_STORE_NAME)) {
-          database.createObjectStore(LOCAL_TTML_STORE_NAME);
+        if (!database.objectStoreNames.contains(LOCAL_LYRICS_STORE_NAME)) {
+          database.createObjectStore(LOCAL_LYRICS_STORE_NAME, {
+            keyPath: "trackId",
+          });
         }
       };
 
@@ -41,7 +54,7 @@ function getLocalTTMLDatabase() {
         const database = request.result;
         database.onversionchange = () => {
           database.close();
-          localTTMLDatabasePromise = null;
+          localDatabasePromise = null;
         };
         resolve(database);
       };
@@ -51,49 +64,62 @@ function getLocalTTMLDatabase() {
     });
   }
 
-  return localTTMLDatabasePromise;
+  return localDatabasePromise;
 }
 
-/** 
- * Get a local TTML for a specific track
- * @param trackId The ID of the track
- * @returns The local TTML object or null if not found
- */
-export async function getLocalTTML(trackId: string): Promise<any | null> {
+async function getLocalLyricsRecord(trackId: string): Promise<LocalLyricsRecord | null> {
   if (!trackId) return null;
 
-  const database = await getLocalTTMLDatabase();
-  const transaction = database.transaction(LOCAL_TTML_STORE_NAME, "readonly");
-  const store = transaction.objectStore(LOCAL_TTML_STORE_NAME);
+  const database = await getLocalDatabase();
+  const transaction = database.transaction(LOCAL_LYRICS_STORE_NAME, "readonly");
+  const store = transaction.objectStore(LOCAL_LYRICS_STORE_NAME);
   return (await requestToPromise(store.get(trackId))) ?? null;
 }
 
-/** 
- * Save a local TTML for a specific track
- * @param trackId The ID of the track
- * @param lyrics The TTML lyrics object to save
+/**
+ * Get a local TTML for a specific track.
+ * @param trackId The ID of the track.
+ * @returns The local TTML object or null if not found.
+ */
+export async function getLocalTTML(trackId: string): Promise<object | null> {
+  const record = await getLocalLyricsRecord(trackId);
+  return record?.lyrics ?? null;
+}
+
+/**
+ * Save a local TTML for a specific track.
+ * @param trackId The ID of the track.
+ * @param lyrics The TTML lyrics object to save.
  */
 export async function saveLocalTTML(trackId: string, lyrics: object): Promise<void> {
   if (!trackId) return;
 
-  const database = await getLocalTTMLDatabase();
-  const transaction = database.transaction(LOCAL_TTML_STORE_NAME, "readwrite");
-  const store = transaction.objectStore(LOCAL_TTML_STORE_NAME);
+  const now = new Date().toISOString();
+  const database = await getLocalDatabase();
+  const transaction = database.transaction(LOCAL_LYRICS_STORE_NAME, "readwrite");
+  const store = transaction.objectStore(LOCAL_LYRICS_STORE_NAME);
 
-  store.put(lyrics, trackId);
+  const record: LocalLyricsRecord = {
+    trackId,
+    lyrics,
+    source: LYRICS_SOURCE.USER_UPLOAD,
+    addedAt: now,
+  };
+
+  store.put(record);
   await transactionToPromise(transaction);
 }
 
-/** 
- * Remove a local TTML for a specific track
- * @param trackId The ID of the track
+/**
+ * Remove a local TTML for a specific track.
+ * @param trackId The ID of the track.
  */
 export async function removeLocalTTML(trackId: string): Promise<void> {
   if (!trackId) return;
 
-  const database = await getLocalTTMLDatabase();
-  const transaction = database.transaction(LOCAL_TTML_STORE_NAME, "readwrite");
-  const store = transaction.objectStore(LOCAL_TTML_STORE_NAME);
+  const database = await getLocalDatabase();
+  const transaction = database.transaction(LOCAL_LYRICS_STORE_NAME, "readwrite");
+  const store = transaction.objectStore(LOCAL_LYRICS_STORE_NAME);
 
   store.delete(trackId);
   await transactionToPromise(transaction);

--- a/src/utils/Lyrics/fetchLyrics.ts
+++ b/src/utils/Lyrics/fetchLyrics.ts
@@ -1,7 +1,7 @@
 import { GetExpireStore } from "@spikerko/tools/Cache";
 import Defaults, { isDev } from "../../components/Global/Defaults.ts";
 import Platform from "../../components/Global/Platform.ts";
-import { SpotifyPlayer } from "../../components/Global/SpotifyPlayer.ts";
+import { SpotifyPlayer, TrackIdFromUri } from "../../components/Global/SpotifyPlayer.ts";
 import PageView, { PageContainer } from "../../components/Pages/PageView.ts";
 import { IsCompactMode } from "../../components/Utils/CompactMode.ts";
 import Fullscreen from "../../components/Utils/Fullscreen.ts";
@@ -57,11 +57,6 @@ export default async function fetchLyrics(uri: string): Promise<[object | string
     return ["unknown-track", 400];
   }
 
-  if (uri.startsWith("spotify:local:")) {
-    storage.set("currentlyFetching", "false");
-    return ["local-track", 400];
-  }
-
   const currFetching = storage.get("currentlyFetching");
   if (currFetching === "true") {
     storage.set("currentlyFetching", "false");
@@ -74,7 +69,7 @@ export default async function fetchLyrics(uri: string): Promise<[object | string
     LyricsContent.classList.add("HiddenTransitioned");
   }
 
-  const trackId = uri.split(":")[2];
+  const trackId = TrackIdFromUri(uri);
 
   // Only load local TTML if TTML maker mode is on
   if (storage.get("devMode") === "true") {
@@ -140,6 +135,12 @@ export default async function fetchLyrics(uri: string): Promise<[object | string
       storage.set("currentlyFetching", "false");
       HideLoaderContainer();
     }
+  }
+
+  // If no local lyrics exists, then do not fetch from API for local files
+  if (uri.startsWith("spotify:local:")) {
+    storage.set("currentlyFetching", "false");
+    return ["local-track", 400];
   }
 
   if (LyricsStore) {

--- a/src/utils/Lyrics/fetchLyrics.ts
+++ b/src/utils/Lyrics/fetchLyrics.ts
@@ -12,8 +12,8 @@ import { getLocalTTML } from "./LocalTTML.ts";
 import { ProcessLyrics } from "./ProcessLyrics.ts";
 
 export const LyricsStore = GetExpireStore<any>("SpicyLyrics_LyricsStore", 12, {
-  Unit: "Days",
-  Duration: 3,
+    Unit: "Days",
+    Duration: 3,
 }, isDev as true);
 
 export default async function fetchLyrics(uri: string): Promise<[object | string, number] | null> {
@@ -76,28 +76,31 @@ export default async function fetchLyrics(uri: string): Promise<[object | string
 
   const trackId = uri.split(":")[2];
 
-  let localTTML = null;
-  try {
-    localTTML = await getLocalTTML(trackId);
-  } catch (error) {
-    console.error("Error retrieving local TTML override:", error);
-  }
-
-  if (localTTML) {
-    if (localTTML?.IncludesRomanization) {
-      PageContainer?.classList.add("Lyrics_RomanizationAvailable");
-    } else {
-      PageContainer?.classList.remove("Lyrics_RomanizationAvailable");
+  // Only load local TTML if TTML maker mode is on
+  if (storage.get("devMode") === "true") {
+    let localTTML = null;
+    try {
+      localTTML = await getLocalTTML(trackId);
+    } catch (error) {
+      console.error("Error retrieving local TTML override:", error);
     }
 
-    storage.set("currentLyricsData", JSON.stringify(localTTML));
-    storage.set("currentlyFetching", "false");
-    HideLoaderContainer();
-    Defaults.CurrentLyricsType = localTTML.Type;
-    PageContainer?.querySelector<HTMLElement>(".ContentBox")?.classList.remove("LyricsHidden");
-    PageContainer?.querySelector(".ContentBox .LyricsContainer")?.classList.remove("Hidden");
-    PageView.AppendViewControls(true);
-    return [{ ...localTTML, fromLocalTTML: true }, 200];
+    if (localTTML) {
+      if (localTTML?.IncludesRomanization) {
+        PageContainer?.classList.add("Lyrics_RomanizationAvailable");
+      } else {
+        PageContainer?.classList.remove("Lyrics_RomanizationAvailable");
+      }
+
+      storage.set("currentLyricsData", JSON.stringify(localTTML));
+      storage.set("currentlyFetching", "false");
+      HideLoaderContainer();
+      Defaults.CurrentLyricsType = localTTML.Type;
+      PageContainer?.querySelector<HTMLElement>(".ContentBox")?.classList.remove("LyricsHidden");
+      PageContainer?.querySelector(".ContentBox .LyricsContainer")?.classList.remove("Hidden");
+      PageView.AppendViewControls(true);
+      return [{ ...localTTML, fromLocalTTML: true }, 200];
+    }
   }
 
   // Check if there's already data in localStorage

--- a/src/utils/Lyrics/fetchLyrics.ts
+++ b/src/utils/Lyrics/fetchLyrics.ts
@@ -8,6 +8,7 @@ import Fullscreen from "../../components/Utils/Fullscreen.ts";
 import { Query } from "../API/Query.ts";
 import { SetWaitingForHeight } from "../Scrolling/ScrollToActiveLine.ts";
 import storage from "../storage.ts";
+import { getLocalTTML } from "./LocalTTML.ts";
 import { ProcessLyrics } from "./ProcessLyrics.ts";
 
 export const LyricsStore = GetExpireStore<any>("SpicyLyrics_LyricsStore", 12, {
@@ -74,6 +75,30 @@ export default async function fetchLyrics(uri: string): Promise<[object | string
   }
 
   const trackId = uri.split(":")[2];
+
+  let localTTML = null;
+  try {
+    localTTML = await getLocalTTML(trackId);
+  } catch (error) {
+    console.error("Error retrieving local TTML override:", error);
+  }
+
+  if (localTTML) {
+    if (localTTML?.IncludesRomanization) {
+      PageContainer?.classList.add("Lyrics_RomanizationAvailable");
+    } else {
+      PageContainer?.classList.remove("Lyrics_RomanizationAvailable");
+    }
+
+    storage.set("currentLyricsData", JSON.stringify(localTTML));
+    storage.set("currentlyFetching", "false");
+    HideLoaderContainer();
+    Defaults.CurrentLyricsType = localTTML.Type;
+    PageContainer?.querySelector<HTMLElement>(".ContentBox")?.classList.remove("LyricsHidden");
+    PageContainer?.querySelector(".ContentBox .LyricsContainer")?.classList.remove("Hidden");
+    PageView.AppendViewControls(true);
+    return [{ ...localTTML, fromLocalTTML: true }, 200];
+  }
 
   // Check if there's already data in localStorage
   const savedLyricsData = storage.get("currentLyricsData")?.toString();

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -1,4 +1,5 @@
 import Defaults from "../components/Global/Defaults.ts";
+import { openLocalLyricsManagerModal } from "../components/ReactComponents/Settings/LocalLyricsManager.tsx";
 import storage from "./storage.ts";
 import { RemoveCurrentLyrics_AllCaches, RemoveCurrentLyrics_StateCache, RemoveLyricsCache } from "./LyricsCacheTools.ts";
 
@@ -39,6 +40,13 @@ function devSettings(SettingsSection: any) {
     "Clear Current Song Lyrics from internal state",
     "Clear Current Lyrics",
     () => RemoveCurrentLyrics_StateCache(true)
+  );
+
+  settings.addButton(
+    "manage-local-lyrics",
+    "Open the local lyrics manager",
+    "View Local Lyrics",
+    () => openLocalLyricsManagerModal()
   );
 
   settings.addToggle("dev-mode", "TTML Maker mode (previously Dev Mode)", Defaults.DevMode, () => {


### PR DESCRIPTION
Introduces a persistent storage system for local TTML!
Now when loading a TTML file will save its data to IndexedDB, persisting the lyrics across sessions. Added a new menu in settings allowing users to view and delete their custom lyrics.

- Integrates IndexedDB persistence into the lyrics fetching logic and loads local TTML when "TTML Maker mode" is active.
- Adds a "Local Lyrics Manager" modal to view, delete, or clear all saved lyrics records.
- Allow adding lyrics for local files and persisting through IndexedDB.