### PR TITLE
Add Disable Lyrics Not Found Notice option

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -118,6 +118,14 @@ async function main() {
     Defaults.SettingsOnTop = storage.get("settingsOnTop") === "true";
   }
 
+  if (!storage.get("disableLyricsNotFoundNotice")) {
+    storage.set("disableLyricsNotFoundNotice", "false");
+  }
+
+  if (storage.get("disableLyricsNotFoundNotice")) {
+    Defaults.DisableLyricsNotFoundNotice = storage.get("disableLyricsNotFoundNotice") === "true";
+  }
+
   if (!storage.get("disablePopupLyrics")) {
     storage.set("disablePopupLyrics", "false");
   }
@@ -220,6 +228,12 @@ async function main() {
 
   if (Defaults.SettingsOnTop) {
     document.body.classList.add("sl_settings_top");
+  }
+
+  if (Defaults.DisableLyricsNotFoundNotice) {
+    document.body.classList.add("sl_hide_lyrics_not_found_notice");
+  } else {
+    document.body.classList.remove("sl_hide_lyrics_not_found_notice");
   }
 
   // Lets set out the Settings Menu

--- a/src/components/Global/Defaults.ts
+++ b/src/components/Global/Defaults.ts
@@ -30,6 +30,7 @@ const Defaults = {
   PopupLyricsAllowed: true,
   ViewControlsPosition: "Top",
   SettingsOnTop: true,
+  DisableLyricsNotFoundNotice: false,
   DeveloperMode: false,
 };
 

--- a/src/css/default.scss
+++ b/src/css/default.scss
@@ -149,6 +149,16 @@ body.sl_settings_top {
   }
 }
 
+body.sl_hide_lyrics_not_found_notice {
+  #SpicyLyricsPage .ContentBox .LyricsContainer .LyricsContent .LyricsNotice {
+
+    .notice-footer,
+    .notice-descriptor {
+      display: none !important;
+    }
+  }
+}
+
 #spicy-lyrics-settings,
 #spicy-lyrics-dev-settings,
 #spicy-lyrics-settings-info {

--- a/src/css/default.scss
+++ b/src/css/default.scss
@@ -147,15 +147,9 @@ body.sl_settings_top {
   #spicy-lyrics-settings-info {
     order: -1;
   }
-}
-
 body.sl_hide_lyrics_not_found_notice {
   #SpicyLyricsPage .ContentBox .LyricsContainer .LyricsContent .LyricsNotice {
-
-    .notice-footer,
-    .notice-descriptor {
-      display: none !important;
-    }
+    display: none !important;
   }
 }
 

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -178,6 +178,20 @@ function generalSettings(SettingsSection: any) {
     }
   );
 
+  settings.addToggle(
+    "disable-lyrics-not-found-notice",
+    "Disable Lyrics Not Found Notice",
+    Defaults.DisableLyricsNotFoundNotice,
+    () => {
+      const isDisabled = settings.getFieldValue("disable-lyrics-not-found-notice") === "true";
+      storage.set(
+        "disableLyricsNotFoundNotice",
+        isDisabled ? "true" : "false"
+      );
+      document.body.classList.toggle("sl_hide_lyrics_not_found_notice", isDisabled);
+    }
+  );
+
   settings.addDropDown(
     "viewcontrols-position",
     "View Controls Position",

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -183,7 +183,7 @@ function generalSettings(SettingsSection: any) {
     "Disable Lyrics Not Found Notice",
     Defaults.DisableLyricsNotFoundNotice,
     () => {
-      const isDisabled = settings.getFieldValue("disable-lyrics-not-found-notice") === "true";
+      const isDisabled = settings.getFieldValue("disable-lyrics-not-found-notice") as boolean;
       storage.set(
         "disableLyricsNotFoundNotice",
         isDisabled ? "true" : "false"


### PR DESCRIPTION
Add an option to disable a Discord ad notice that makes me skip songs without lyrics more often which is a bad UX.

<img width="622" height="400" alt="image" src="https://github.com/user-attachments/assets/fb54ff01-9350-4c8a-acc4-4d7999d3ceb4" />
