### PR TITLE
fix: resolve disconnected Arabic characters in RTL lyrics

### DIFF
--- a/src/utils/Lyrics/Applyer/Synced/Syllable.ts
+++ b/src/utils/Lyrics/Applyer/Synced/Syllable.ts
@@ -192,7 +192,7 @@ export function ApplySyllableLyrics(data: LyricsData, UseRomanized: boolean = fa
         ? nextLineStartTime === 0
           ? line.Lead.EndTime
           : lineEndTimeAndNextLineStartTimeDistance < lyricsBetweenShow &&
-              nextLineStartTime > line.Lead.EndTime
+            nextLineStartTime > line.Lead.EndTime
             ? nextLineStartTime
             : line.Lead.EndTime
         : line.Lead.EndTime;
@@ -227,7 +227,8 @@ export function ApplySyllableLyrics(data: LyricsData, UseRomanized: boolean = fa
         UseRomanized && lead.RomanizedText !== undefined ? lead.RomanizedText : lead.Text
       ).split("").length;
 
-      const IfLetterCapable = IsLetterCapable(letterLength, totalDuration);
+      // Disable letter-by-letter sync for RTL languages to preserve cursive text shaping
+      const IfLetterCapable = !isRtl(lead.Text) && IsLetterCapable(letterLength, totalDuration);
 
       if (IfLetterCapable) {
         word = document.createElement("div");
@@ -336,7 +337,8 @@ export function ApplySyllableLyrics(data: LyricsData, UseRomanized: boolean = fa
             UseRomanized && bw.RomanizedText !== undefined ? bw.RomanizedText : bw.Text
           ).split("").length;
 
-          const IfLetterCapable = IsLetterCapable(letterLength, totalDuration);
+          // Disable letter-by-letter sync for RTL languages to preserve cursive text shaping
+          const IfLetterCapable = !isRtl(bw.Text) && IsLetterCapable(letterLength, totalDuration);
 
           if (IfLetterCapable) {
             bwE = document.createElement("div");

--- a/src/utils/Lyrics/Applyer/Synced/Syllable.ts
+++ b/src/utils/Lyrics/Applyer/Synced/Syllable.ts
@@ -227,10 +227,9 @@ export function ApplySyllableLyrics(data: LyricsData, UseRomanized: boolean = fa
         UseRomanized && lead.RomanizedText !== undefined ? lead.RomanizedText : lead.Text
       ).split("").length;
 
-      // Disable letter-by-letter sync for RTL languages to preserve cursive text shaping
-      const IfLetterCapable = !isRtl(lead.Text) && IsLetterCapable(letterLength, totalDuration);
+      const IfLetterCapable = IsLetterCapable(letterLength, totalDuration);
 
-      if (IfLetterCapable) {
+      if (IfLetterCapable && !isRtl(lead.Text)) {
         word = document.createElement("div");
         const letters = (
           UseRomanized && lead.RomanizedText !== undefined ? lead.RomanizedText : lead.Text
@@ -337,10 +336,9 @@ export function ApplySyllableLyrics(data: LyricsData, UseRomanized: boolean = fa
             UseRomanized && bw.RomanizedText !== undefined ? bw.RomanizedText : bw.Text
           ).split("").length;
 
-          // Disable letter-by-letter sync for RTL languages to preserve cursive text shaping
-          const IfLetterCapable = !isRtl(bw.Text) && IsLetterCapable(letterLength, totalDuration);
+          const IfLetterCapable = IsLetterCapable(letterLength, totalDuration);
 
-          if (IfLetterCapable) {
+          if (IfLetterCapable && !isRtl(bw.Text)) {
             bwE = document.createElement("div");
             const letters = (
               UseRomanized && bw.RomanizedText !== undefined ? bw.RomanizedText : bw.Text

--- a/src/utils/Lyrics/fetchLyrics.ts
+++ b/src/utils/Lyrics/fetchLyrics.ts
@@ -9,9 +9,6 @@ import { Query } from "../API/Query.ts";
 import { SetWaitingForHeight } from "../Scrolling/ScrollToActiveLine.ts";
 import storage from "../storage.ts";
 import { ProcessLyrics } from "./ProcessLyrics.ts";
-import { convertToLineLyrics } from "./tools.ts";
-import isRtl from "./isRtl.ts";
-
 export const LyricsStore = GetExpireStore<any>("SpicyLyrics_LyricsStore", 12, {
   Unit: "Days",
   Duration: 3,
@@ -221,22 +218,8 @@ export default async function fetchLyrics(uri: string): Promise<[object | string
     }
 
     // const providerLyrics = JSON.parse(lyricsText);
-    let lyrics = JSON.parse(lyricsText);
+    const lyrics = JSON.parse(lyricsText);
 
-    if (lyrics.Type === "Syllable") {
-      let isRtlSong = false;
-      try {
-        const firstVocal = lyrics.Content?.find((c: any) => c.Type === "Vocal");
-        const sampleText = firstVocal?.Lead?.Syllables?.map((s: any) => s.Text).join("") || "";
-        if (isRtl(sampleText)) {
-          isRtlSong = true;
-        }
-      } catch (e) { }
-
-      if (isRtlSong) {
-        lyrics = convertToLineLyrics(lyrics);
-      }
-    }
     IsSpicyRenderer ? await ProcessLyrics(lyrics) : null;
 
     storage.set("currentLyricsData", JSON.stringify(lyrics));

--- a/src/utils/Lyrics/fetchLyrics.ts
+++ b/src/utils/Lyrics/fetchLyrics.ts
@@ -9,6 +9,8 @@ import { Query } from "../API/Query.ts";
 import { SetWaitingForHeight } from "../Scrolling/ScrollToActiveLine.ts";
 import storage from "../storage.ts";
 import { ProcessLyrics } from "./ProcessLyrics.ts";
+import { convertToLineLyrics } from "./tools.ts";
+import isRtl from "./isRtl.ts";
 
 export const LyricsStore = GetExpireStore<any>("SpicyLyrics_LyricsStore", 12, {
   Unit: "Days",
@@ -219,8 +221,22 @@ export default async function fetchLyrics(uri: string): Promise<[object | string
     }
 
     // const providerLyrics = JSON.parse(lyricsText);
-    const lyrics = JSON.parse(lyricsText);
+    let lyrics = JSON.parse(lyricsText);
 
+    if (lyrics.Type === "Syllable") {
+      let isRtlSong = false;
+      try {
+        const firstVocal = lyrics.Content?.find((c: any) => c.Type === "Vocal");
+        const sampleText = firstVocal?.Lead?.Syllables?.map((s: any) => s.Text).join("") || "";
+        if (isRtl(sampleText)) {
+          isRtlSong = true;
+        }
+      } catch (e) { }
+
+      if (isRtlSong) {
+        lyrics = convertToLineLyrics(lyrics);
+      }
+    }
     IsSpicyRenderer ? await ProcessLyrics(lyrics) : null;
 
     storage.set("currentLyricsData", JSON.stringify(lyrics));


### PR DESCRIPTION
This PR fixes the issue where Arabic and other RTL languages appear as disconnected characters.

The Issue:
Character-level or syllable-level synchronization breaks the CSS cursive text shaping required for Arabic letters to connect properly.

The Solution:

1. In fetchLyrics.ts, when RTL text is detected in "Syllable" type lyrics, the code now automatically converts them to "Line" sync using the existing convertToLineLyrics utility.

2. In Syllable.ts, added a fallback check to prevent RTL text from passing the IfLetterCapable condition, ensuring words stay intact.

This ensures RTL characters remain connected while preserving the overall karaoke experience for LTR languages.


Here is before:
<img width="984" height="505" alt="image" src="https://github.com/user-attachments/assets/64d0ec6b-1764-4717-bb0c-e91d410e98e4" />

Here is after:
<img width="926" height="545" alt="image" src="https://github.com/user-attachments/assets/72addfeb-879f-4f92-a212-fc3f6816bf9e" />
