### PR TITLE
Fix Linux lyric progress jitter

### DIFF
--- a/src/utils/Gets/GetProgress.ts
+++ b/src/utils/Gets/GetProgress.ts
@@ -5,9 +5,73 @@ interface SyncedPosition {
   Position: number;
 }
 
+interface ProgressSnapshot {
+  TrackId: string | null;
+  Position: number;
+}
+
+interface PlayerProgressState {
+  positionAsOfTimestamp?: number;
+  timestamp?: number;
+  isPaused?: boolean;
+}
+
 let syncedPosition: SyncedPosition | null = null;
+let lastReportedProgress: ProgressSnapshot | null = null;
 const syncTimings = [0.05, 0.1, 0.15, 0.75];
 let canSyncNonLocalTimestamp = SpotifyPlayer?.IsPlaying ? syncTimings.length : 0;
+const PROGRESS_POSITION_OFFSET = 85;
+const BACKWARD_JITTER_TOLERANCE = 120;
+
+function getPrimaryProgressState(): PlayerProgressState | null {
+  const originState = (Spicetify?.Player as any)?.origin?._state;
+  if (originState?.positionAsOfTimestamp != null && originState?.timestamp != null) {
+    return originState;
+  }
+
+  const playerData = (Spicetify?.Player as any)?.data;
+  if (playerData?.positionAsOfTimestamp != null && playerData?.timestamp != null) {
+    return playerData;
+  }
+
+  const platformState = Spicetify?.Platform?.PlayerAPI?._state;
+  if (platformState?.positionAsOfTimestamp != null && platformState?.timestamp != null) {
+    return platformState;
+  }
+
+  return null;
+}
+
+function normalizeProgress(position: number): number {
+  const trackId = SpotifyPlayer.GetId() ?? null;
+  const duration = SpotifyPlayer.GetDuration();
+  let normalizedPosition = Math.max(0, position);
+
+  if (duration > 0) {
+    normalizedPosition = Math.min(normalizedPosition, duration);
+  }
+
+  if (!lastReportedProgress || lastReportedProgress.TrackId !== trackId) {
+    lastReportedProgress = {
+      TrackId: trackId,
+      Position: normalizedPosition,
+    };
+    return normalizedPosition;
+  }
+
+  const backwardDelta = lastReportedProgress.Position - normalizedPosition;
+
+  if (backwardDelta > 0 && backwardDelta <= BACKWARD_JITTER_TOLERANCE) {
+    normalizedPosition = lastReportedProgress.Position;
+  }
+
+  lastReportedProgress = {
+    TrackId: trackId,
+    Position: normalizedPosition,
+  };
+
+  return normalizedPosition;
+}
 
 export const requestPositionSync = () => {
   try {
@@ -66,6 +130,20 @@ export default function GetProgress() {
     return Spicetify.Player.getProgress();
   }
 
+  const primaryState = getPrimaryProgressState();
+  if (primaryState) {
+    const positionAsOfTimestamp = Number(primaryState.positionAsOfTimestamp);
+    const timestamp = Number(primaryState.timestamp);
+
+    if (Number.isFinite(positionAsOfTimestamp) && Number.isFinite(timestamp)) {
+      if (primaryState.isPaused ?? !Spicetify.Player.isPlaying()) {
+        return normalizeProgress(positionAsOfTimestamp);
+      }
+
+      return normalizeProgress(positionAsOfTimestamp + (Date.now() - timestamp));
+    }
+  }
+
   if (!syncedPosition) {
     console.error("Synced Position: Unavailable");
     if (SpotifyPlayer?._DEPRECATED_?.GetTrackPosition) {
@@ -86,12 +164,12 @@ export default function GetProgress() {
 
   // Calculate and return the current track position
   if (!Spicetify.Player.isPlaying()) {
-    return SpotifyPlatform.PlayerAPI._state.positionAsOfTimestamp; // Position remains static when paused
+    return normalizeProgress(SpotifyPlatform.PlayerAPI._state.positionAsOfTimestamp); // Position remains static when paused
   }
 
   // Calculate and return the current track position
   const FinalPosition = Position + deltaTime;
-  return FinalPosition + 85;
+  return normalizeProgress(FinalPosition + PROGRESS_POSITION_OFFSET);
 }
 
 // DEPRECATED

--- a/src/utils/Gets/GetProgress.ts
+++ b/src/utils/Gets/GetProgress.ts
@@ -140,7 +140,11 @@ export default function GetProgress() {
         return normalizeProgress(positionAsOfTimestamp);
       }
 
-      return normalizeProgress(positionAsOfTimestamp + (Date.now() - timestamp));
+      // Apply the same playback offset used by the syncedPosition path so
+      // lyric/progress timing stays aligned regardless of which state source is available.
+      return normalizeProgress(
+        positionAsOfTimestamp + (Date.now() - timestamp) + PROGRESS_POSITION_OFFSET,
+      );
     }
   }
 

--- a/src/utils/Lyrics/Animator/Lyrics/LyricsAnimator.ts
+++ b/src/utils/Lyrics/Animator/Lyrics/LyricsAnimator.ts
@@ -464,7 +464,7 @@ function getElementState(
   endTime: number
 ): "NotSung" | "Active" | "Sung" {
   if (currentTime < startTime) return "NotSung";
-  if (currentTime > endTime) return "Sung";
+  if (currentTime >= endTime) return "Sung";
   return "Active";
 }
 

--- a/src/utils/Lyrics/Animator/Lyrics/LyricsSetter.ts
+++ b/src/utils/Lyrics/Animator/Lyrics/LyricsSetter.ts
@@ -17,6 +17,16 @@ interface _SyllableLead {
   [key: string]: any;
 }
 
+function getElementStatus(
+  currentTime: number,
+  startTime: number,
+  endTime: number
+): ElementStatus {
+  if (currentTime < startTime) return "NotSung";
+  if (currentTime >= endTime) return "Sung";
+  return "Active";
+}
+
 export function TimeSetter(PreCurrentPosition: number): void {
   const CurrentPosition = PreCurrentPosition + timeOffset;
   const CurrentLyricsType = Defaults.CurrentLyricsType as ExtendedLyricsType;
@@ -37,7 +47,7 @@ export function TimeSetter(PreCurrentPosition: number): void {
         total: line.EndTime - line.StartTime,
       };
 
-      if (lineTimes.start <= CurrentPosition && CurrentPosition <= lineTimes.end) {
+      if (getElementStatus(CurrentPosition, lineTimes.start, lineTimes.end) === "Active") {
         line.Status = "Active";
 
         // Check if Syllables exists
@@ -46,28 +56,16 @@ export function TimeSetter(PreCurrentPosition: number): void {
         const words = line.Syllables.Lead;
         for (let j = 0; j < words.length; j++) {
           const word = words[j];
-          if (word.StartTime <= CurrentPosition && CurrentPosition <= word.EndTime) {
-            word.Status = "Active";
-          } else if (word.StartTime >= CurrentPosition) {
-            word.Status = "NotSung";
-          } else if (word.EndTime <= CurrentPosition) {
-            word.Status = "Sung";
-          }
+          word.Status = getElementStatus(CurrentPosition, word.StartTime, word.EndTime);
 
           if (word?.LetterGroup) {
             for (let k = 0; k < word.Letters.length; k++) {
               const letter = word.Letters[k];
-              if (letter.StartTime <= CurrentPosition && CurrentPosition <= letter.EndTime) {
-                letter.Status = "Active";
-              } else if (letter.StartTime >= CurrentPosition) {
-                letter.Status = "NotSung";
-              } else if (letter.EndTime <= CurrentPosition) {
-                letter.Status = "Sung";
-              }
+              letter.Status = getElementStatus(CurrentPosition, letter.StartTime, letter.EndTime);
             }
           }
         }
-      } else if (lineTimes.start >= CurrentPosition) {
+      } else if (lineTimes.start > CurrentPosition) {
         line.Status = "NotSung";
 
         // Check if Syllables exists
@@ -116,22 +114,16 @@ export function TimeSetter(PreCurrentPosition: number): void {
         total: line.EndTime - line.StartTime,
       };
 
-      if (lineTimes.start <= CurrentPosition && CurrentPosition <= lineTimes.end) {
+      if (getElementStatus(CurrentPosition, lineTimes.start, lineTimes.end) === "Active") {
         line.Status = "Active";
         if (line.DotLine) {
           const leads = line.Syllables.Lead;
           for (let i = 0; i < leads.length; i++) {
             const dot = leads[i];
-            if (dot.StartTime <= CurrentPosition && CurrentPosition <= dot.EndTime) {
-              dot.Status = "Active";
-            } else if (dot.StartTime >= CurrentPosition) {
-              dot.Status = "NotSung";
-            } else if (dot.EndTime <= CurrentPosition) {
-              dot.Status = "Sung";
-            }
+            dot.Status = getElementStatus(CurrentPosition, dot.StartTime, dot.EndTime);
           }
         }
-      } else if (lineTimes.start >= CurrentPosition) {
+      } else if (lineTimes.start > CurrentPosition) {
         line.Status = "NotSung";
         if (line.DotLine) {
           const leads = line.Syllables.Lead;


### PR DESCRIPTION
## Summary
- Stabilized progress reporting on Linux by preferring primary player state when available and normalizing reported position values.
- Added backward-jitter suppression to prevent small regressions from causing lyric flicker during playback updates.
- Tightened lyric state boundaries so items switch to `Sung` exactly at `endTime`, and simplified status assignment for lines, words, letters, and dot lyrics.

## Testing
- Tested on Windows 11 (25H2) and Arch Linux with Hyprland.
- Verified the change set touches progress calculation and lyric state transitions only.
- Confirmed boundary checks now classify `currentTime >= endTime` as `Sung` consistently across animator/setter paths.