### PR TITLE
Allow uploading TTML files for local songs

### DIFF
--- a/src/components/ReactComponents/LyricsManager/components/UploadTTMLModal.tsx
+++ b/src/components/ReactComponents/LyricsManager/components/UploadTTMLModal.tsx
@@ -39,11 +39,6 @@ export default function UploadTTMLModal({ onBack, onDone }: UploadTTMLModalProps
       return;
     }
 
-    if (uri.startsWith("spotify:local:")) {
-      toast.warning("Local TTML files are not available on local songs", { duration: 5000 });
-      return;
-    }
-
     setUploading(true);
 
     const reader = new FileReader();


### PR DESCRIPTION
Upon my testing, I found zero issues with using local TTML files on local songs. They are a great way to somewhat add lyrics support for local songs, so it seems unnecessary to disallow it for no reason.